### PR TITLE
improved atimport() for other at-rules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,10 +200,13 @@ module.exports = function(css){
    * Parse import
    */
 
-  function atimport() {
-    var m = match(/^@import *([^;\n]+);\s*/);
+  function atruleSimple(ruleName) {
+    var re = new RegExp('^@'+ruleName+' *([^;\\n]+);\\s*');
+    var m = match(re);
     if (!m) return;
-    return { import: m[1].trim() };
+    var ret = {}
+    ret[ruleName] = m[1].trim();
+    return ret;
   }
 
   /**
@@ -234,7 +237,8 @@ module.exports = function(css){
   function atrule() {
     return keyframes()
       || media()
-      || atimport();
+      || atruleSimple('import')
+      || atruleSimple('charset')
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -200,10 +200,26 @@ module.exports = function(css){
    * Parse import
    */
 
-  function atruleSimple(ruleName) {
-    var re = new RegExp('^@'+ruleName+' *([^;\\n]+);\\s*');
-    var m = match(re);
+  function atimport() {
+    return _atruleSimple('import')
+  }
+
+  /**
+   * Parse charset
+   */
+
+  function atcharset() {
+    return _atruleSimple('charset');
+  }
+
+  /**
+   * Parse non-block at-rules
+   */
+
+  function _atruleSimple(ruleName) {
+    var m = match(new RegExp('^@'+ruleName+' *([^;\\n]+);\\s*'));
     if (!m) return;
+
     var ret = {}
     ret[ruleName] = m[1].trim();
     return ret;
@@ -237,8 +253,8 @@ module.exports = function(css){
   function atrule() {
     return keyframes()
       || media()
-      || atruleSimple('import')
-      || atruleSimple('charset')
+      || atimport()
+      || atcharset();
   }
 
   /**

--- a/test/cases/charset.css
+++ b/test/cases/charset.css
@@ -1,0 +1,2 @@
+@charset "UTF-8";       /* Set the encoding of the style sheet to Unicode UTF-8*/
+@charset 'iso-8859-15'; /* Set the encoding of the style sheet to Latin-9 (Western European languages, with euro sign) */

--- a/test/cases/charset.json
+++ b/test/cases/charset.json
@@ -1,0 +1,12 @@
+{
+  "stylesheet": {
+    "rules": [
+      {
+        "charset": "\"UTF-8\""
+      },
+      {
+        "charset": "'iso-8859-15'"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I found that the parser cannot parse '@charset' rule.

so, modified atimport() for other at-rules and renamed "atimport" to "atruleSimple"

"simple" in "atruleSimple" means "not for block rule". If you have better idea, change it please.

and added test case for @charset.
