### PR TITLE
Support semicolons in quoted strings in declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -113,7 +112,7 @@ module.exports = function(css){
     if (!match(/^:\s*/)) return;
 
     // val
-    var val = match(/^([^};]+)\s*/);
+    var val = match(/^((?:'[^']*'|"[^"]*"|[^};])+)\s*/);
     if (!val) return;
     val = val[0].trim();
 


### PR DESCRIPTION
Fixes parsing of `background: url('data:image/jpg;...')`
