### PR TITLE
Consume excess semicolons

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = function(css){
     val = val[0].trim();
 
     // ;
-    match(/^;\s*/);
+    match(/^[;\s]*/);
 
     return { property: prop, value: val };
   }


### PR DESCRIPTION
Handles cases like `div { color: blue;;; padding: 0; }`.

Yes, it's valid CSS to do that, unfortunately.
