### PR TITLE
Support escaped quotes in quoted strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = function(css){
     if (!match(/^:\s*/)) return;
 
     // val
-    var val = match(/^((?:'[^']*'|"[^"]*"|[^};])+)\s*/);
+    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^};])+)\s*/);
     if (!val) return;
     val = val[0].trim();
 


### PR DESCRIPTION
Takes care of things like:

    content: "Hello, \"name\""

and the IE voice family hack:

     voice-family: "\"}\""
