### PR TITLE
Support quotes in selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,9 +93,13 @@ module.exports = function(css){
    */
 
   function selector() {
-    var m = match(/^([^{]+)/);
+    var m = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^{])+)/);
     if (!m) return;
-    return m[0].trim().split(/\s*,\s*/);
+    var matches = m[0].trim().match(/((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^,])+)/g);
+    for (var i=0, len=matches.length; i<len; ++i) {
+      matches[i] = matches[i].trim();
+    }
+    return matches;
   }
 
   /**


### PR DESCRIPTION
Handles cases such as `abbr[title*="{"] { ... }`.

Okay, this is a complicated/controversial one.

By the way, I opted for a `for` loop here (instead of `Array.prototype.map`) because this means css-parse can still work on an older browser.

...that, and also, I can't find a way to make the regex consume the whitespaces.

For the curious: `((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^{])+)` broken down is:
- `'(?:\\'|.)*?'` - looks for a single-quoted string, consuming the escaped ones along the way
- `"(?:\\"|.)*?"` - consumes a double-quoted string in the same fashion

And (`'...'`|`"..."`|`[^,]`)+ is pretty much how it works -- it looks for a single-quoted string, a double-quoted string, or something that's not a `{`, in that order.
