### PR TITLE
Handle keyframe names with no whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ module.exports = function(css){
     var vendor = m[1];
 
     // identifier
-    var m = match(/^([-\w]+)\s+/);
+    var m = match(/^([-\w]+)\s*/);
     if (!m) return;
     var name = m[1];
 


### PR DESCRIPTION
Takes care of things like `@keyframes rotate{...}` where
there's no space before the {.
