### PR TITLE
Support unquoted data URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = function(css){
     if (!match(/^:\s*/)) return;
 
     // val
-    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|[^};])+)\s*/);
+    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)\s*/);
     if (!val) return;
     val = val[0].trim();
 


### PR DESCRIPTION
Takes care of cases like `background: url(data:image/png;base64,...)`.

It is valid CSS to define URLs without quotes (`url(xxx)`) so the example above is perfectly valid CSS.

For what its worth, I ran into this problem trying to parse Yahoo's CSS.
