### PR TITLE
Correctly handle comments containing slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function(css){
   function comment() {
     if ('/' == css[0] && '*' == css[1]) {
       var i = 2;
-      while ('*' != css[i] && '/' != css[i + 1]) ++i;
+      while ('*' != css[i] || '/' != css[i + 1]) ++i;
       i += 2;
       css = css.slice(i);
       whitespace();

--- a/test/cases/comment.url.css
+++ b/test/cases/comment.url.css
@@ -1,0 +1,5 @@
+/* http://foo.com/bar/baz.html */
+
+foo { /*/*/
+  bar: baz; /* http://foo.com/bar/baz.html */
+}

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -1,0 +1,17 @@
+{
+  "stylesheet": {
+    "rules": [
+      {
+        "selectors": [
+          "foo"
+        ],
+        "declarations": [
+          {
+            "property": "bar",
+            "value": "baz"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The parser currently messes up if it encounters a comment containing slashes because of an incorrect logical operator being used.

Tests attached.
