### PR TITLE
Parse Comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,10 @@ module.exports = function(css){
     var node;
     var rules = [];
     whitespace();
-    comments();
+    comments(rules);
     while (css[0] != '}' && (node = atrule() || rule())) {
-      comments();
       rules.push(node);
+      comments(rules);
     }
     return rules;
   }
@@ -64,8 +64,11 @@ module.exports = function(css){
    * Parse comments;
    */
 
-  function comments() {
-    while (comment()) ;
+  function comments(rules) {
+    rules = rules || [];
+    var c;
+    while (c = comment()) rules.push(c);
+    return rules;
   }
 
   /**
@@ -77,9 +80,10 @@ module.exports = function(css){
       var i = 2;
       while ('*' != css[i] || '/' != css[i + 1]) ++i;
       i += 2;
+      var comment = css.slice(2, i - 2);
       css = css.slice(i);
       whitespace();
-      return true;
+      return {comment: comment};
     }
   }
 

--- a/test/cases/charset.json
+++ b/test/cases/charset.json
@@ -5,7 +5,13 @@
         "charset": "\"UTF-8\""
       },
       {
+        "comment": " Set the encoding of the style sheet to Unicode UTF-8"
+      },
+      {
         "charset": "'iso-8859-15'"
+      },
+      {
+        "comment": " Set the encoding of the style sheet to Latin-9 (Western European languages, with euro sign) "
       }
     ]
   }

--- a/test/cases/comment.json
+++ b/test/cases/comment.json
@@ -2,6 +2,15 @@
   "stylesheet": {
     "rules": [
       {
+        "comment": " foo "
+      },
+      {
+        "comment": " bar "
+      },
+      {
+        "comment": " baz\n\nasdfasdfasdf\nasdfasdfasdf\nasdfasdfasdf\nasdfasdfasdf\n\n"
+      },
+      {
         "selectors": [
           "foo"
         ],

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -2,6 +2,9 @@
   "stylesheet": {
     "rules": [
       {
+        "comment": " http://foo.com/bar/baz.html "
+      },
+      {
         "selectors": [
           "foo"
         ],


### PR DESCRIPTION
This parses comments and they appear in the output as `{"comment": "comment test"}`  e.g.:

``` css
/* http://foo.com/bar/baz.html */

foo { /*/*/
  bar: baz; /* http://foo.com/bar/baz.html */
}
```

becomes

``` js
{
  "stylesheet": {
    "rules": [
      {
        "comment": " http://foo.com/bar/baz.html "
      },
      {
        "selectors": [
          "foo"
        ],
        "declarations": [
          {
            "property": "bar",
            "value": "baz"
          }
        ]
      }
    ]
  }
}
```

Note that it ignores any comments that aren't either top-level or direct descendants of `@media` queries.

I'd add support for direct descendants of `@keyframes` but it would break https://github.com/visionmedia/rework/blob/master/lib/visit.js so that needs to be fixed to check `if (keyframe.declarations)` first.

Closes #13
