### PR TITLE
Add support for @page at-rules with nested @margin at-rules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,50 @@ module.exports = function(css){
     return { media: media, rules: style };
   }
 
+  /**
+   * Parse paged media.
+   */
+
+  function atpage() {
+    var m = match(/^@page */);
+    if (!m) return;
+
+    var sel = selector() || [];
+    var decls = [];
+
+    if (!open()) return;
+    comments();
+
+    // declarations
+    var decl;
+    while (decl = declaration() || atmargin()) {
+      decls.push(decl);
+      comments();
+    }
+
+    if (!close()) return;
+
+    return {
+      type: "page",
+      selectors: sel,
+      declarations: decls
+    };
+  }
+
+  /**
+   * Parse margin at-rules
+   */
+
+  function atmargin() {
+    var m = match(/^@([a-z\-]+) */);
+    if (!m) return;
+    var type = m[1]
+
+    return {
+      type: type,
+      declarations: declarations()
+    }
+  }
 
   /**
    * Parse import
@@ -281,8 +325,8 @@ module.exports = function(css){
       || supports()
       || atimport()
       || atcharset()
-      || atnamespace();
-
+      || atnamespace()
+      || atpage();
   }
 
   /**

--- a/test/cases/paged-media.css
+++ b/test/cases/paged-media.css
@@ -1,0 +1,15 @@
+@page toc, index:blank {
+  color: green;
+
+  @top-left {
+    content: "foo";
+    color: blue;
+  }
+  @top-right {
+    content: "bar";
+  }
+}
+
+@page {
+  font-size: 16pt;
+}

--- a/test/cases/paged-media.json
+++ b/test/cases/paged-media.json
@@ -1,0 +1,51 @@
+{
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "page",
+        "selectors": [
+          "toc",
+          "index:blank"
+        ],
+        "declarations": [
+          {
+            "property": "color",
+            "value": "green"
+          },
+          {
+            "type": "top-left",
+            "declarations": [
+              {
+                "property": "content",
+                "value": "\"foo\""
+              },
+              {
+                "property": "color",
+                "value": "blue"
+              }
+            ]
+          },
+          {
+            "type": "top-right",
+            "declarations": [
+              {
+                "property": "content",
+                "value": "\"bar\""
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "page",
+        "selectors": [],
+        "declarations": [
+          {
+            "property": "font-size",
+            "value": "16pt"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Reference:
http://dev.w3.org/csswg/css3-page/

I've added code to support `@page` rules with nested margin at-rules such as:

```
@page toc, index:blank {
  color: green;
  @top-left {
    content: "foo";
    color: blue;
  }
  @top-right {
    content: "bar";
  }
}
```

I had to slightly break out of the convention you've established and add a `type` property to these rules otherwise it can be ambiguous.

With other @rules you've used the type as an object's key, .e.g `{meda: "screen"}`, but that doesn't work with @page rules, so I explicitly report a type property.

Perhaps it's worth considering adding the type property to all @rule blocks. As the spec grows and more @rules are introduced, it might make it easier to handle.

I'd be happy to submit another pull request with this addition if you'd like.
