### PR TITLE
Add option to include line and column numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,7 +365,10 @@ module.exports = function(css, opts){
     if (!sel) return;
     comments();
     var ret = { selectors: sel, declarations: declarations() };
-    if (loc) ret.loc = loc;
+    if (loc) {
+      if (opts.file) loc.file = opts.file;
+      ret.loc = loc;
+    }
     return ret;
   }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "CSS parser",
   "keywords": ["css", "parser", "stylesheet"],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --require should"
+  },
   "devDependencies": {
     "mocha": "*",
     "should": "*"

--- a/test/cases/comment.json
+++ b/test/cases/comment.json
@@ -19,7 +19,11 @@
             "property": "bar",
             "value": "baz"
           }
-        ]
+        ],
+        "loc": {
+          "line": 12,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -13,7 +13,11 @@
             "property": "bar",
             "value": "baz"
           }
-        ]
+        ],
+        "loc": {
+          "line": 3,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/media.json
+++ b/test/cases/media.json
@@ -17,7 +17,11 @@
                 "property": "color",
                 "value": "#300"
               }
-            ]
+            ],
+            "loc": {
+              "line": 2,
+              "column": 3
+            }
           },
           {
             "selectors": [
@@ -32,7 +36,11 @@
                 "property": "margin",
                 "value": "0 auto"
               }
-            ]
+            ],
+            "loc": {
+              "line": 6,
+              "column": 3
+            }
           }
         ]
       },
@@ -52,7 +60,11 @@
                 "property": "color",
                 "value": "#000"
               }
-            ]
+            ],
+            "loc": {
+              "line": 13,
+              "column": 3
+            }
           },
           {
             "selectors": [
@@ -67,7 +79,11 @@
                 "property": "border",
                 "value": "0.5pt solid #666"
               }
-            ]
+            ],
+            "loc": {
+              "line": 17,
+              "column": 3
+            }
           }
         ]
       }

--- a/test/cases/media.messed.json
+++ b/test/cases/media.messed.json
@@ -17,7 +17,11 @@
                 "property": "color",
                 "value": "#300"
               }
-            ]
+            ],
+            "loc": {
+              "line": 1,
+              "column": 28
+            }
           },
           {
             "selectors": [
@@ -32,7 +36,11 @@
                 "property": "margin",
                 "value": "0 auto"
               }
-            ]
+            ],
+            "loc": {
+              "line": 7,
+              "column": 3
+            }
           }
         ]
       },
@@ -52,7 +60,11 @@
                 "property": "color",
                 "value": "#000"
               }
-            ]
+            ],
+            "loc": {
+              "line": 19,
+              "column": 15
+            }
           },
           {
             "selectors": [
@@ -67,7 +79,11 @@
                 "property": "border",
                 "value": "0.5pt solid #666"
               }
-            ]
+            ],
+            "loc": {
+              "line": 23,
+              "column": 15
+            }
           }
         ]
       }

--- a/test/cases/messed-up.json
+++ b/test/cases/messed-up.json
@@ -10,7 +10,11 @@
             "property": "foo\n  ",
             "value": "'bar'"
           }
-        ]
+        ],
+        "loc": {
+          "line": 1,
+          "column": 1
+        }
       },
       {
         "selectors": [
@@ -25,7 +29,11 @@
             "property": "bar",
             "value": "baz"
           }
-        ]
+        ],
+        "loc": {
+          "line": 5,
+          "column": 4
+        }
       },
       {
         "selectors": [
@@ -40,7 +48,11 @@
             "property": "bar\n     ",
             "value": "baz"
           }
-        ]
+        ],
+        "loc": {
+          "line": 6,
+          "column": 4
+        }
       }
     ]
   }

--- a/test/cases/no-semi.json
+++ b/test/cases/no-semi.json
@@ -14,7 +14,11 @@
             "property": "the-species",
             "value": "called \"ferrets\""
           }
-        ]
+        ],
+        "loc": {
+          "line": 2,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/props.json
+++ b/test/cases/props.json
@@ -18,7 +18,11 @@
             "property": "*even",
             "value": "'ie crap'"
           }
-        ]
+        ],
+        "loc": {
+          "line": 2,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/quoted.json
+++ b/test/cases/quoted.json
@@ -10,7 +10,11 @@
             "property": "background",
             "value": "url('some;stuff;here') 50% 50% no-repeat"
           }
-        ]
+        ],
+        "loc": {
+          "line": 1,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/rule.json
+++ b/test/cases/rule.json
@@ -10,7 +10,11 @@
             "property": "bar",
             "value": "'baz'"
           }
-        ]
+        ],
+        "loc": {
+          "line": 1,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/rules.json
+++ b/test/cases/rules.json
@@ -10,7 +10,11 @@
             "property": "name",
             "value": "'tobi'"
           }
-        ]
+        ],
+        "loc": {
+          "line": 1,
+          "column": 1
+        }
       },
       {
         "selectors": [
@@ -21,7 +25,11 @@
             "property": "name",
             "value": "'loki'"
           }
-        ]
+        ],
+        "loc": {
+          "line": 4,
+          "column": 1
+        }
       }
     ]
   }

--- a/test/cases/supports.json
+++ b/test/cases/supports.json
@@ -17,7 +17,11 @@
                 "property": "display",
                 "value": "flex"
               }
-            ]
+            ],
+            "loc": {
+              "line": 2,
+              "column": 3
+            }
           }
         ]
       }

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -16,7 +16,7 @@ describe('parse(str)', function(){
     it('should parse ' + file, function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
       var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
-      var ret = parse(css);
+      var ret = parse(css, { loc: true });
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);
     })


### PR DESCRIPTION
When `{ loc: true }` is passed as second argument all `rule` nodes will include a `loc` property that contains the line and column number of the first selector. This info is read by css-stringify and can be used to generate a source-map.
