### PR TITLE
include column position

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,26 @@ module.exports = function(css, options){
    */
 
   var lineno = 1;
+  var column = 1;
+
+  /**
+   * Update lineno and column based on `str`.
+   */
+
+  function updatePosition(str) {
+    var lines = str.match(/\n/g);
+    if (lines) lineno += lines.length;
+    var i = str.lastIndexOf('\n');
+    column = ~i ? str.length-i : column + str.length;
+  }
 
   function position() {
-    var start = { line: lineno };
+    var start = { line: lineno, column: column };
     if (!options.position) return positionNoop;
     return function(node){
       node.position = {
         start: start,
-        end: { line: lineno }
+        end: { line: lineno, column: column }
       };
 
       return node;
@@ -74,7 +86,7 @@ module.exports = function(css, options){
     var m = re.exec(css);
     if (!m) return;
     var str = m[0];
-    lineno += lines(str);
+    updatePosition(str);
     css = css.slice(str.length);
     return m;
   }
@@ -111,10 +123,11 @@ module.exports = function(css, options){
     i += 2;
 
     var str = css.slice(2, i - 2);
+    column += 2;
+    updatePosition(str);
     css = css.slice(i);
+    column += 2;
     whitespace();
-
-    lineno += lines(str);
 
     return pos({
       type: 'comment',
@@ -422,14 +435,6 @@ module.exports = function(css, options){
 
   return stylesheet();
 };
-
-/**
- * Lines within `str`.
- */
-
-function lines(str) {
-  return str.split('\n').length - 1;
-}
 
 /**
  * Return `node`.

--- a/index.js
+++ b/index.js
@@ -28,9 +28,17 @@ module.exports = function(css, options){
         start: start,
         end: { line: lineno, column: column }
       };
-
+      whitespace();
       return node;
     }
+  }
+
+  /**
+   * Return `node`.
+   */
+  function positionNoop(node) {
+    whitespace();
+    return node;
   }
 
   /**
@@ -59,7 +67,7 @@ module.exports = function(css, options){
    */
 
   function close() {
-    return match(/^}\s*/);
+    return match(/^}/);
   }
 
   /**
@@ -127,12 +135,10 @@ module.exports = function(css, options){
     updatePosition(str);
     css = css.slice(i);
     column += 2;
-    var ret = pos({
+    return pos({
       type: 'comment',
       comment: str
     });
-    whitespace();
-    return ret;
   }
 
   /**
@@ -397,9 +403,7 @@ module.exports = function(css, options){
     if (!m) return;
     var ret = { type: name };
     ret[name] = m[1].trim();
-    ret = pos(ret);
-    whitespace();
-    return ret;
+    return pos(ret);
   }
 
   /**
@@ -438,10 +442,3 @@ module.exports = function(css, options){
   return stylesheet();
 };
 
-/**
- * Return `node`.
- */
-
-function positionNoop(node) {
-  return node;
-}

--- a/index.js
+++ b/index.js
@@ -127,12 +127,12 @@ module.exports = function(css, options){
     updatePosition(str);
     css = css.slice(i);
     column += 2;
-    whitespace();
-
-    return pos({
+    var ret = pos({
       type: 'comment',
       comment: str
     });
+    whitespace();
+    return ret;
   }
 
   /**
@@ -393,11 +393,13 @@ module.exports = function(css, options){
 
   function _atrule(name) {
     var pos = position();
-    var m = match(new RegExp('^@' + name + ' *([^;\\n]+);\\s*'));
+    var m = match(new RegExp('^@' + name + ' *([^;\\n]+);'));
     if (!m) return;
     var ret = { type: name };
     ret[name] = m[1].trim();
-    return pos(ret);
+    ret = pos(ret);
+    whitespace();
+    return ret;
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -167,18 +167,18 @@ module.exports = function(css, options){
     if (!match(/^:\s*/)) return;
 
     // val
-    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)\s*/);
+    var val = match(/^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^\)]*?\)|[^};])+)/);
     if (!val) return;
-    val = val[0].trim();
+
+    var ret = pos({
+      type: 'declaration',
+      property: prop,
+      value: val[0].trim()
+    });
 
     // ;
     match(/^[;\s]*/);
-
-    return pos({
-      type: 'declaration',
-      property: prop,
-      value: val
-    });
+    return ret;
   }
 
   /**

--- a/test/cases/charset.json
+++ b/test/cases/charset.json
@@ -4,19 +4,59 @@
     "rules": [
       {
         "type": "charset",
-        "charset": "\"UTF-8\""
+        "charset": "\"UTF-8\"",
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        }
       },
       {
         "type": "comment",
-        "comment": " Set the encoding of the style sheet to Unicode UTF-8"
+        "comment": " Set the encoding of the style sheet to Unicode UTF-8",
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 25
+          },
+          "end": {
+            "line": 2,
+            "column": 1
+          }
+        }
       },
       {
         "type": "charset",
-        "charset": "'iso-8859-15'"
+        "charset": "'iso-8859-15'",
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 25
+          }
+        }
       },
       {
         "type": "comment",
-        "comment": " Set the encoding of the style sheet to Latin-9 (Western European languages, with euro sign) "
+        "comment": " Set the encoding of the style sheet to Latin-9 (Western European languages, with euro sign) ",
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 25
+          },
+          "end": {
+            "line": 2,
+            "column": 122
+          }
+        }
       }
     ]
   }

--- a/test/cases/charset.json
+++ b/test/cases/charset.json
@@ -12,7 +12,7 @@
           },
           "end": {
             "line": 1,
-            "column": 25
+            "column": 18
           }
         }
       },
@@ -25,8 +25,8 @@
             "column": 25
           },
           "end": {
-            "line": 2,
-            "column": 1
+            "line": 1,
+            "column": 82
           }
         }
       },
@@ -40,7 +40,7 @@
           },
           "end": {
             "line": 2,
-            "column": 25
+            "column": 24
           }
         }
       },

--- a/test/cases/comment.json
+++ b/test/cases/comment.json
@@ -101,7 +101,7 @@
           },
           "end": {
             "line": 7,
-            "column": 3
+            "column": 2
           }
         }
       },

--- a/test/cases/comment.json
+++ b/test/cases/comment.json
@@ -74,8 +74,8 @@
                 "column": 7
               },
               "end": {
-                "line": 6,
-                "column": 3
+                "line": 5,
+                "column": 17
               }
             }
           },

--- a/test/cases/comment.json
+++ b/test/cases/comment.json
@@ -4,7 +4,17 @@
     "rules": [
       {
         "type": "comment",
-        "comment": " 1 "
+        "comment": " 1 ",
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
       },
       {
         "type": "rule",
@@ -14,34 +24,114 @@
         "declarations": [
           {
             "type": "comment",
-            "comment": " 2 "
+            "comment": " 2 ",
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 8
+              },
+              "end": {
+                "line": 3,
+                "column": 15
+              }
+            }
           },
           {
             "type": "comment",
-            "comment": " 3 "
+            "comment": " 3 ",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 10
+              }
+            }
           },
           {
             "type": "comment",
-            "comment": ""
+            "comment": "",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 7
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "foo",
-            "value": "'bar'"
+            "value": "'bar'",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 7
+              },
+              "end": {
+                "line": 6,
+                "column": 3
+              }
+            }
           },
           {
             "type": "comment",
-            "comment": " 4 "
+            "comment": " 4 ",
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 10
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 3,
+            "column": 1
+          },
+          "end": {
+            "line": 7,
+            "column": 3
+          }
+        }
       },
       {
         "type": "comment",
-        "comment": " 5 "
+        "comment": " 5 ",
+        "position": {
+          "start": {
+            "line": 7,
+            "column": 3
+          },
+          "end": {
+            "line": 7,
+            "column": 10
+          }
+        }
       },
       {
         "type": "comment",
-        "comment": " 6 "
+        "comment": " 6 ",
+        "position": {
+          "start": {
+            "line": 9,
+            "column": 1
+          },
+          "end": {
+            "line": 9,
+            "column": 8
+          }
+        }
       }
     ]
   }

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -75,7 +75,7 @@
               },
               "end": {
                 "line": 6,
-                "column": 13
+                "column": 11
               }
             }
           },

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -4,11 +4,31 @@
     "rules": [
       {
         "type": "comment",
-        "comment": " http://foo.com/bar/baz.html "
+        "comment": " http://foo.com/bar/baz.html ",
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 34
+          }
+        }
       },
       {
         "type": "comment",
-        "comment": ""
+        "comment": "",
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 5
+          }
+        }
       },
       {
         "type": "rule",
@@ -18,22 +38,72 @@
         "declarations": [
           {
             "type": "comment",
-            "comment": "/"
+            "comment": "/",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 7
+              },
+              "end": {
+                "line": 4,
+                "column": 12
+              }
+            }
           },
           {
             "type": "comment",
-            "comment": " something "
+            "comment": " something ",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 18
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "bar",
-            "value": "baz"
+            "value": "baz",
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 13
+              }
+            }
           },
           {
             "type": "comment",
-            "comment": " http://foo.com/bar/baz.html "
+            "comment": " http://foo.com/bar/baz.html ",
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 13
+              },
+              "end": {
+                "line": 6,
+                "column": 46
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 8,
+            "column": 1
+          }
+        }
       }
     ]
   }

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -100,8 +100,8 @@
             "column": 1
           },
           "end": {
-            "line": 8,
-            "column": 1
+            "line": 7,
+            "column": 2
           }
         }
       }

--- a/test/cases/document.json
+++ b/test/cases/document.json
@@ -16,11 +16,41 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": ".0001"
+                "value": ".0001",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        }
       }
     ]
   }

--- a/test/cases/document.json
+++ b/test/cases/document.json
@@ -35,8 +35,8 @@
                 "column": 3
               },
               "end": {
-                "line": 5,
-                "column": 1
+                "line": 4,
+                "column": 4
               }
             }
           }
@@ -47,8 +47,8 @@
             "column": 1
           },
           "end": {
-            "line": 6,
-            "column": 1
+            "line": 5,
+            "column": 2
           }
         }
       }

--- a/test/cases/import.json
+++ b/test/cases/import.json
@@ -4,23 +4,73 @@
     "rules": [
       {
         "type": "import",
-        "import": "url(\"fineprint.css\") print"
+        "import": "url(\"fineprint.css\") print",
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 36
+          }
+        }
       },
       {
         "type": "import",
-        "import": "url(\"bluish.css\") projection, tv"
+        "import": "url(\"bluish.css\") projection, tv",
+        "position": {
+          "start": {
+            "line": 3,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 42
+          }
+        }
       },
       {
         "type": "import",
-        "import": "'custom.css'"
+        "import": "'custom.css'",
+        "position": {
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 22
+          }
+        }
       },
       {
         "type": "import",
-        "import": "\"common.css\" screen, projection"
+        "import": "\"common.css\" screen, projection",
+        "position": {
+          "start": {
+            "line": 5,
+            "column": 1
+          },
+          "end": {
+            "line": 5,
+            "column": 41
+          }
+        }
       },
       {
         "type": "import",
-        "import": "url('landscape.css') screen and (orientation:landscape)"
+        "import": "url('landscape.css') screen and (orientation:landscape)",
+        "position": {
+          "start": {
+            "line": 6,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 65
+          }
+        }
       }
     ]
   }

--- a/test/cases/import.messed.json
+++ b/test/cases/import.messed.json
@@ -4,23 +4,73 @@
     "rules": [
       {
         "type": "import",
-        "import": "url(\"fineprint.css\") print"
+        "import": "url(\"fineprint.css\") print",
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 4
+          },
+          "end": {
+            "line": 2,
+            "column": 39
+          }
+        }
       },
       {
         "type": "import",
-        "import": "url(\"bluish.css\") projection, tv"
+        "import": "url(\"bluish.css\") projection, tv",
+        "position": {
+          "start": {
+            "line": 3,
+            "column": 3
+          },
+          "end": {
+            "line": 3,
+            "column": 44
+          }
+        }
       },
       {
         "type": "import",
-        "import": "'custom.css'"
+        "import": "'custom.css'",
+        "position": {
+          "start": {
+            "line": 4,
+            "column": 7
+          },
+          "end": {
+            "line": 4,
+            "column": 28
+          }
+        }
       },
       {
         "type": "import",
-        "import": "\"common.css\" screen, projection"
+        "import": "\"common.css\" screen, projection",
+        "position": {
+          "start": {
+            "line": 5,
+            "column": 3
+          },
+          "end": {
+            "line": 5,
+            "column": 45
+          }
+        }
       },
       {
         "type": "import",
-        "import": "url('landscape.css') screen and (orientation:landscape)"
+        "import": "url('landscape.css') screen and (orientation:landscape)",
+        "position": {
+          "start": {
+            "line": 7,
+            "column": 3
+          },
+          "end": {
+            "line": 7,
+            "column": 67
+          }
+        }
       }
     ]
   }

--- a/test/cases/keyframes.complex.json
+++ b/test/cases/keyframes.complex.json
@@ -15,14 +15,44 @@
               {
                 "type": "declaration",
                 "property": "top",
-                "value": "0"
+                "value": "0",
+                "position": {
+                  "start": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "left",
-                "value": "0"
+                "value": "0",
+                "position": {
+                  "start": {
+                    "line": 2,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 24
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 3
+              }
+            }
           },
           {
             "type": "keyframe",
@@ -33,9 +63,29 @@
               {
                 "type": "declaration",
                 "property": "top",
-                "value": "50px"
+                "value": "50px",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 22
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
           },
           {
             "type": "keyframe",
@@ -48,9 +98,29 @@
               {
                 "type": "declaration",
                 "property": "left",
-                "value": "50px"
+                "value": "50px",
+                "position": {
+                  "start": {
+                    "line": 6,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 26
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 7,
+                "column": 3
+              }
+            }
           },
           {
             "type": "keyframe",
@@ -61,16 +131,56 @@
               {
                 "type": "declaration",
                 "property": "top",
-                "value": "100px"
+                "value": "100px",
+                "position": {
+                  "start": {
+                    "line": 7,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 22
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "left",
-                "value": "100%"
+                "value": "100%",
+                "position": {
+                  "start": {
+                    "line": 7,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 33
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 7,
+                "column": 3
+              },
+              "end": {
+                "line": 8,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 8,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/keyframes.complex.json
+++ b/test/cases/keyframes.complex.json
@@ -49,8 +49,8 @@
                 "column": 3
               },
               "end": {
-                "line": 3,
-                "column": 3
+                "line": 2,
+                "column": 25
               }
             }
           },
@@ -82,8 +82,8 @@
                 "column": 3
               },
               "end": {
-                "line": 4,
-                "column": 3
+                "line": 3,
+                "column": 23
               }
             }
           },
@@ -117,8 +117,8 @@
                 "column": 3
               },
               "end": {
-                "line": 7,
-                "column": 3
+                "line": 6,
+                "column": 27
               }
             }
           },
@@ -165,8 +165,8 @@
                 "column": 3
               },
               "end": {
-                "line": 8,
-                "column": 1
+                "line": 7,
+                "column": 34
               }
             }
           }

--- a/test/cases/keyframes.complex.json
+++ b/test/cases/keyframes.complex.json
@@ -23,7 +23,7 @@
                   },
                   "end": {
                     "line": 2,
-                    "column": 16
+                    "column": 14
                   }
                 }
               },
@@ -139,7 +139,7 @@
                   },
                   "end": {
                     "line": 7,
-                    "column": 22
+                    "column": 20
                   }
                 }
               },

--- a/test/cases/keyframes.json
+++ b/test/cases/keyframes.json
@@ -34,8 +34,8 @@
                 "column": 3
               },
               "end": {
-                "line": 5,
-                "column": 3
+                "line": 4,
+                "column": 4
               }
             }
           },
@@ -67,8 +67,8 @@
                 "column": 3
               },
               "end": {
-                "line": 8,
-                "column": 1
+                "line": 7,
+                "column": 4
               }
             }
           }

--- a/test/cases/keyframes.json
+++ b/test/cases/keyframes.json
@@ -15,9 +15,29 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": "0"
+                "value": "0",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 3
+              }
+            }
           },
           {
             "type": "keyframe",
@@ -28,11 +48,41 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": "1"
+                "value": "1",
+                "position": {
+                  "start": {
+                    "line": 6,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 8,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 8,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/keyframes.json
+++ b/test/cases/keyframes.json
@@ -22,8 +22,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 4,
-                    "column": 3
+                    "line": 3,
+                    "column": 15
                   }
                 }
               }
@@ -55,8 +55,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 7,
-                    "column": 3
+                    "line": 6,
+                    "column": 15
                   }
                 }
               }

--- a/test/cases/keyframes.messed.json
+++ b/test/cases/keyframes.messed.json
@@ -34,8 +34,8 @@
                 "column": 18
               },
               "end": {
-                "line": 4,
-                "column": 1
+                "line": 3,
+                "column": 7
               }
             }
           },

--- a/test/cases/keyframes.messed.json
+++ b/test/cases/keyframes.messed.json
@@ -15,9 +15,29 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": "0"
+                "value": "0",
+                "position": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 6
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 1,
+                "column": 18
+              },
+              "end": {
+                "line": 4,
+                "column": 1
+              }
+            }
           },
           {
             "type": "keyframe",
@@ -28,11 +48,41 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": "1"
+                "value": "1",
+                "position": {
+                  "start": {
+                    "line": 6,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 17
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 1
+              },
+              "end": {
+                "line": 6,
+                "column": 18
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 19
+          }
+        }
       }
     ]
   }

--- a/test/cases/keyframes.messed.json
+++ b/test/cases/keyframes.messed.json
@@ -22,8 +22,8 @@
                     "column": 4
                   },
                   "end": {
-                    "line": 3,
-                    "column": 6
+                    "line": 2,
+                    "column": 14
                   }
                 }
               }
@@ -56,7 +56,7 @@
                   },
                   "end": {
                     "line": 6,
-                    "column": 17
+                    "column": 16
                   }
                 }
               }

--- a/test/cases/keyframes.vendor.json
+++ b/test/cases/keyframes.vendor.json
@@ -35,8 +35,8 @@
                 "column": 3
               },
               "end": {
-                "line": 3,
-                "column": 3
+                "line": 2,
+                "column": 22
               }
             }
           },
@@ -68,8 +68,8 @@
                 "column": 3
               },
               "end": {
-                "line": 4,
-                "column": 1
+                "line": 3,
+                "column": 20
               }
             }
           }

--- a/test/cases/keyframes.vendor.json
+++ b/test/cases/keyframes.vendor.json
@@ -16,9 +16,29 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": "0"
+                "value": "0",
+                "position": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 21
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 3
+              }
+            }
           },
           {
             "type": "keyframe",
@@ -29,11 +49,41 @@
               {
                 "type": "declaration",
                 "property": "opacity",
-                "value": "1"
+                "value": "1",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/media.json
+++ b/test/cases/media.json
@@ -49,8 +49,8 @@
                 "column": 3
               },
               "end": {
-                "line": 6,
-                "column": 3
+                "line": 5,
+                "column": 4
               }
             }
           },
@@ -97,8 +97,8 @@
                 "column": 3
               },
               "end": {
-                "line": 10,
-                "column": 1
+                "line": 9,
+                "column": 4
               }
             }
           }
@@ -109,8 +109,8 @@
             "column": 1
           },
           "end": {
-            "line": 12,
-            "column": 1
+            "line": 10,
+            "column": 2
           }
         }
       },
@@ -161,8 +161,8 @@
                 "column": 3
               },
               "end": {
-                "line": 17,
-                "column": 3
+                "line": 16,
+                "column": 4
               }
             }
           },
@@ -209,8 +209,8 @@
                 "column": 3
               },
               "end": {
-                "line": 21,
-                "column": 1
+                "line": 20,
+                "column": 4
               }
             }
           }

--- a/test/cases/media.json
+++ b/test/cases/media.json
@@ -22,8 +22,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 4,
-                    "column": 5
+                    "line": 3,
+                    "column": 24
                   }
                 }
               },
@@ -37,8 +37,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 5,
-                    "column": 3
+                    "line": 4,
+                    "column": 16
                   }
                 }
               }
@@ -70,8 +70,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 8,
-                    "column": 5
+                    "line": 7,
+                    "column": 20
                   }
                 }
               },
@@ -85,8 +85,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 9,
-                    "column": 3
+                    "line": 8,
+                    "column": 19
                   }
                 }
               }
@@ -134,8 +134,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 15,
-                    "column": 5
+                    "line": 14,
+                    "column": 21
                   }
                 }
               },
@@ -149,8 +149,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 16,
-                    "column": 3
+                    "line": 15,
+                    "column": 16
                   }
                 }
               }
@@ -182,8 +182,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 19,
-                    "column": 5
+                    "line": 18,
+                    "column": 17
                   }
                 }
               },
@@ -197,8 +197,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 20,
-                    "column": 3
+                    "line": 19,
+                    "column": 29
                   }
                 }
               }

--- a/test/cases/media.json
+++ b/test/cases/media.json
@@ -15,14 +15,44 @@
               {
                 "type": "declaration",
                 "property": "background",
-                "value": "#fffef0"
+                "value": "#fffef0",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "color",
-                "value": "#300"
+                "value": "#300",
+                "position": {
+                  "start": {
+                    "line": 4,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 3
+              }
+            }
           },
           {
             "type": "rule",
@@ -33,16 +63,56 @@
               {
                 "type": "declaration",
                 "property": "max-width",
-                "value": "35em"
+                "value": "35em",
+                "position": {
+                  "start": {
+                    "line": 7,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "margin",
-                "value": "0 auto"
+                "value": "0 auto",
+                "position": {
+                  "start": {
+                    "line": 8,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 10,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 12,
+            "column": 1
+          }
+        }
       },
       {
         "type": "media",
@@ -57,14 +127,44 @@
               {
                 "type": "declaration",
                 "property": "background",
-                "value": "#fff"
+                "value": "#fff",
+                "position": {
+                  "start": {
+                    "line": 14,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 15,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "color",
-                "value": "#000"
+                "value": "#000",
+                "position": {
+                  "start": {
+                    "line": 15,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 13,
+                "column": 3
+              },
+              "end": {
+                "line": 17,
+                "column": 3
+              }
+            }
           },
           {
             "type": "rule",
@@ -75,16 +175,56 @@
               {
                 "type": "declaration",
                 "property": "padding",
-                "value": "1in"
+                "value": "1in",
+                "position": {
+                  "start": {
+                    "line": 18,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "border",
-                "value": "0.5pt solid #666"
+                "value": "0.5pt solid #666",
+                "position": {
+                  "start": {
+                    "line": 19,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 17,
+                "column": 3
+              },
+              "end": {
+                "line": 21,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 12,
+            "column": 1
+          },
+          "end": {
+            "line": 21,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/media.messed.json
+++ b/test/cases/media.messed.json
@@ -49,8 +49,8 @@
                 "column": 28
               },
               "end": {
-                "line": 7,
-                "column": 3
+                "line": 6,
+                "column": 4
               }
             }
           },
@@ -97,8 +97,8 @@
                 "column": 3
               },
               "end": {
-                "line": 15,
-                "column": 3
+                "line": 14,
+                "column": 2
               }
             }
           }
@@ -109,8 +109,8 @@
             "column": 1
           },
           "end": {
-            "line": 17,
-            "column": 1
+            "line": 15,
+            "column": 4
           }
         }
       },
@@ -161,8 +161,8 @@
                 "column": 15
               },
               "end": {
-                "line": 23,
-                "column": 15
+                "line": 22,
+                "column": 16
               }
             }
           },
@@ -209,8 +209,8 @@
                 "column": 15
               },
               "end": {
-                "line": 27,
-                "column": 1
+                "line": 26,
+                "column": 16
               }
             }
           }

--- a/test/cases/media.messed.json
+++ b/test/cases/media.messed.json
@@ -22,8 +22,8 @@
                     "column": 1
                   },
                   "end": {
-                    "line": 5,
-                    "column": 5
+                    "line": 4,
+                    "column": 20
                   }
                 }
               },
@@ -37,8 +37,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 6,
-                    "column": 3
+                    "line": 5,
+                    "column": 15
                   }
                 }
               }
@@ -70,8 +70,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 11,
-                    "column": 5
+                    "line": 10,
+                    "column": 20
                   }
                 }
               },
@@ -85,8 +85,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 14,
-                    "column": 1
+                    "line": 11,
+                    "column": 19
                   }
                 }
               }
@@ -134,8 +134,8 @@
                     "column": 15
                   },
                   "end": {
-                    "line": 21,
-                    "column": 15
+                    "line": 20,
+                    "column": 31
                   }
                 }
               },
@@ -149,8 +149,8 @@
                     "column": 15
                   },
                   "end": {
-                    "line": 22,
-                    "column": 15
+                    "line": 21,
+                    "column": 26
                   }
                 }
               }
@@ -182,8 +182,8 @@
                     "column": 15
                   },
                   "end": {
-                    "line": 25,
-                    "column": 15
+                    "line": 24,
+                    "column": 27
                   }
                 }
               },
@@ -197,8 +197,8 @@
                     "column": 15
                   },
                   "end": {
-                    "line": 26,
-                    "column": 15
+                    "line": 25,
+                    "column": 39
                   }
                 }
               }

--- a/test/cases/media.messed.json
+++ b/test/cases/media.messed.json
@@ -15,14 +15,44 @@
               {
                 "type": "declaration",
                 "property": "background",
-                "value": "#fffef0"
+                "value": "#fffef0",
+                "position": {
+                  "start": {
+                    "line": 4,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "color",
-                "value": "#300"
+                "value": "#300",
+                "position": {
+                  "start": {
+                    "line": 5,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 7,
+                "column": 3
+              }
+            }
           },
           {
             "type": "rule",
@@ -33,16 +63,56 @@
               {
                 "type": "declaration",
                 "property": "max-width",
-                "value": "35em"
+                "value": "35em",
+                "position": {
+                  "start": {
+                    "line": 10,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 11,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "margin",
-                "value": "0 auto"
+                "value": "0 auto",
+                "position": {
+                  "start": {
+                    "line": 11,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 1
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 7,
+                "column": 3
+              },
+              "end": {
+                "line": 15,
+                "column": 3
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 17,
+            "column": 1
+          }
+        }
       },
       {
         "type": "media",
@@ -57,14 +127,44 @@
               {
                 "type": "declaration",
                 "property": "background",
-                "value": "#fff"
+                "value": "#fff",
+                "position": {
+                  "start": {
+                    "line": 20,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 21,
+                    "column": 15
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "color",
-                "value": "#000"
+                "value": "#000",
+                "position": {
+                  "start": {
+                    "line": 21,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 22,
+                    "column": 15
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 19,
+                "column": 15
+              },
+              "end": {
+                "line": 23,
+                "column": 15
+              }
+            }
           },
           {
             "type": "rule",
@@ -75,16 +175,56 @@
               {
                 "type": "declaration",
                 "property": "padding",
-                "value": "1in"
+                "value": "1in",
+                "position": {
+                  "start": {
+                    "line": 24,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 25,
+                    "column": 15
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "border",
-                "value": "0.5pt solid #666"
+                "value": "0.5pt solid #666",
+                "position": {
+                  "start": {
+                    "line": 25,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 26,
+                    "column": 15
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 23,
+                "column": 15
+              },
+              "end": {
+                "line": 27,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 17,
+            "column": 1
+          },
+          "end": {
+            "line": 27,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/messed-up.json
+++ b/test/cases/messed-up.json
@@ -52,7 +52,7 @@
               },
               "end": {
                 "line": 5,
-                "column": 17
+                "column": 16
               }
             }
           },
@@ -99,7 +99,7 @@
                 "column": 6
               },
               "end": {
-                "line": 12,
+                "line": 11,
                 "column": 6
               }
             }

--- a/test/cases/messed-up.json
+++ b/test/cases/messed-up.json
@@ -30,8 +30,8 @@
             "column": 1
           },
           "end": {
-            "line": 5,
-            "column": 4
+            "line": 3,
+            "column": 10
           }
         }
       },
@@ -78,8 +78,8 @@
             "column": 4
           },
           "end": {
-            "line": 6,
-            "column": 4
+            "line": 5,
+            "column": 25
           }
         }
       },

--- a/test/cases/messed-up.json
+++ b/test/cases/messed-up.json
@@ -11,9 +11,29 @@
           {
             "type": "declaration",
             "property": "foo\n  ",
-            "value": "'bar'"
+            "value": "'bar'",
+            "position": {
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 3,
+                "column": 9
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 5,
+            "column": 4
+          }
+        }
       },
       {
         "type": "rule",
@@ -24,14 +44,44 @@
           {
             "type": "declaration",
             "property": "foo",
-            "value": "bar"
+            "value": "bar",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 9
+              },
+              "end": {
+                "line": 5,
+                "column": 17
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "bar",
-            "value": "baz"
+            "value": "baz",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 17
+              },
+              "end": {
+                "line": 5,
+                "column": 24
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 5,
+            "column": 4
+          },
+          "end": {
+            "line": 6,
+            "column": 4
+          }
+        }
       },
       {
         "type": "rule",
@@ -42,14 +92,44 @@
           {
             "type": "declaration",
             "property": "foo\n     ",
-            "value": "bar"
+            "value": "bar",
+            "position": {
+              "start": {
+                "line": 8,
+                "column": 6
+              },
+              "end": {
+                "line": 12,
+                "column": 6
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "bar\n     ",
-            "value": "baz"
+            "value": "baz",
+            "position": {
+              "start": {
+                "line": 12,
+                "column": 6
+              },
+              "end": {
+                "line": 15,
+                "column": 6
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 6,
+            "column": 4
+          },
+          "end": {
+            "line": 15,
+            "column": 7
+          }
+        }
       }
     ]
   }

--- a/test/cases/namespace.json
+++ b/test/cases/namespace.json
@@ -4,11 +4,31 @@
     "rules": [
       {
         "type": "namespace",
-        "namespace": "\"http://www.w3.org/1999/xhtml\""
+        "namespace": "\"http://www.w3.org/1999/xhtml\"",
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 43
+          }
+        }
       },
       {
         "type": "namespace",
-        "namespace": "svg \"http://www.w3.org/2000/svg\""
+        "namespace": "svg \"http://www.w3.org/2000/svg\"",
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 45
+          }
+        }
       }
     ]
   }

--- a/test/cases/no-semi.json
+++ b/test/cases/no-semi.json
@@ -11,14 +11,44 @@
           {
             "type": "declaration",
             "property": "are",
-            "value": "'all'"
+            "value": "'all'",
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "the-species",
-            "value": "called \"ferrets\""
+            "value": "called \"ferrets\"",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        }
       }
     ]
   }

--- a/test/cases/no-semi.json
+++ b/test/cases/no-semi.json
@@ -45,8 +45,8 @@
             "column": 1
           },
           "end": {
-            "line": 6,
-            "column": 1
+            "line": 5,
+            "column": 2
           }
         }
       }

--- a/test/cases/no-semi.json
+++ b/test/cases/no-semi.json
@@ -18,8 +18,8 @@
                 "column": 3
               },
               "end": {
-                "line": 4,
-                "column": 3
+                "line": 3,
+                "column": 13
               }
             }
           },

--- a/test/cases/paged-media.json
+++ b/test/cases/paged-media.json
@@ -31,8 +31,8 @@
             "column": 1
           },
           "end": {
-            "line": 5,
-            "column": 1
+            "line": 3,
+            "column": 2
           }
         }
       },
@@ -62,8 +62,8 @@
             "column": 1
           },
           "end": {
-            "line": 8,
-            "column": 1
+            "line": 7,
+            "column": 2
           }
         }
       }

--- a/test/cases/paged-media.json
+++ b/test/cases/paged-media.json
@@ -19,8 +19,8 @@
                 "column": 3
               },
               "end": {
-                "line": 3,
-                "column": 1
+                "line": 2,
+                "column": 15
               }
             }
           }
@@ -50,8 +50,8 @@
                 "column": 3
               },
               "end": {
-                "line": 7,
-                "column": 1
+                "line": 6,
+                "column": 18
               }
             }
           }

--- a/test/cases/paged-media.json
+++ b/test/cases/paged-media.json
@@ -12,9 +12,29 @@
           {
             "type": "declaration",
             "property": "color",
-            "value": "green"
+            "value": "green",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 5,
+            "column": 1
+          }
+        }
       },
       {
         "type": "page",
@@ -23,9 +43,29 @@
           {
             "type": "declaration",
             "property": "font-size",
-            "value": "16pt"
+            "value": "16pt",
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 7,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 5,
+            "column": 1
+          },
+          "end": {
+            "line": 8,
+            "column": 1
+          }
+        }
       }
     ]
   }

--- a/test/cases/props.json
+++ b/test/cases/props.json
@@ -11,19 +11,59 @@
           {
             "type": "declaration",
             "property": "are",
-            "value": "'all'"
+            "value": "'all'",
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "the-species",
-            "value": "called \"ferrets\""
+            "value": "called \"ferrets\"",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 3
+              }
+            }
           },
           {
             "type": "declaration",
             "property": "*even",
-            "value": "'ie crap'"
+            "value": "'ie crap'",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 7,
+            "column": 1
+          }
+        }
       }
     ]
   }

--- a/test/cases/props.json
+++ b/test/cases/props.json
@@ -60,8 +60,8 @@
             "column": 1
           },
           "end": {
-            "line": 7,
-            "column": 1
+            "line": 6,
+            "column": 2
           }
         }
       }

--- a/test/cases/props.json
+++ b/test/cases/props.json
@@ -18,8 +18,8 @@
                 "column": 3
               },
               "end": {
-                "line": 4,
-                "column": 3
+                "line": 3,
+                "column": 13
               }
             }
           },
@@ -33,8 +33,8 @@
                 "column": 3
               },
               "end": {
-                "line": 5,
-                "column": 3
+                "line": 4,
+                "column": 32
               }
             }
           },
@@ -48,8 +48,8 @@
                 "column": 3
               },
               "end": {
-                "line": 6,
-                "column": 1
+                "line": 5,
+                "column": 19
               }
             }
           }

--- a/test/cases/quoted.json
+++ b/test/cases/quoted.json
@@ -11,9 +11,29 @@
           {
             "type": "declaration",
             "property": "background",
-            "value": "url('some;stuff;here') 50% 50% no-repeat"
+            "value": "url('some;stuff;here') 50% 50% no-repeat",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/quoted.json
+++ b/test/cases/quoted.json
@@ -18,8 +18,8 @@
                 "column": 3
               },
               "end": {
-                "line": 3,
-                "column": 1
+                "line": 2,
+                "column": 55
               }
             }
           }

--- a/test/cases/rule.json
+++ b/test/cases/rule.json
@@ -11,9 +11,29 @@
           {
             "type": "declaration",
             "property": "bar",
-            "value": "'baz'"
+            "value": "'baz'",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/rule.json
+++ b/test/cases/rule.json
@@ -18,8 +18,8 @@
                 "column": 3
               },
               "end": {
-                "line": 3,
-                "column": 1
+                "line": 2,
+                "column": 13
               }
             }
           }

--- a/test/cases/rules.json
+++ b/test/cases/rules.json
@@ -30,8 +30,8 @@
             "column": 1
           },
           "end": {
-            "line": 4,
-            "column": 1
+            "line": 3,
+            "column": 2
           }
         }
       },

--- a/test/cases/rules.json
+++ b/test/cases/rules.json
@@ -18,8 +18,8 @@
                 "column": 3
               },
               "end": {
-                "line": 3,
-                "column": 1
+                "line": 2,
+                "column": 15
               }
             }
           }
@@ -51,8 +51,8 @@
                 "column": 3
               },
               "end": {
-                "line": 6,
-                "column": 1
+                "line": 5,
+                "column": 15
               }
             }
           }

--- a/test/cases/rules.json
+++ b/test/cases/rules.json
@@ -11,9 +11,29 @@
           {
             "type": "declaration",
             "property": "name",
-            "value": "'tobi'"
+            "value": "'tobi'",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        }
       },
       {
         "type": "rule",
@@ -24,9 +44,29 @@
           {
             "type": "declaration",
             "property": "name",
-            "value": "'loki'"
+            "value": "'loki'",
+            "position": {
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/supports.json
+++ b/test/cases/supports.json
@@ -22,8 +22,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 4,
-                    "column": 5
+                    "line": 3,
+                    "column": 17
                   }
                 }
               },
@@ -37,8 +37,8 @@
                     "column": 5
                   },
                   "end": {
-                    "line": 5,
-                    "column": 3
+                    "line": 4,
+                    "column": 18
                   }
                 }
               }

--- a/test/cases/supports.json
+++ b/test/cases/supports.json
@@ -15,16 +15,56 @@
               {
                 "type": "declaration",
                 "property": "display",
-                "value": "box"
+                "value": "box",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 5
+                  }
+                }
               },
               {
                 "type": "declaration",
                 "property": "display",
-                "value": "flex"
+                "value": "flex",
+                "position": {
+                  "start": {
+                    "line": 4,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 3
+                  }
+                }
               }
-            ]
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 1
+              }
+            }
           }
-        ]
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        }
       }
     ]
   }

--- a/test/cases/supports.json
+++ b/test/cases/supports.json
@@ -49,8 +49,8 @@
                 "column": 3
               },
               "end": {
-                "line": 6,
-                "column": 1
+                "line": 5,
+                "column": 4
               }
             }
           }

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -14,8 +14,8 @@ describe('parse(str)', function(){
     if (~file.indexOf('json')) return;
     file = path.basename(file, '.css');
     it('should parse ' + file, function(){
-      var css = read(path.join('test', 'cases', file + '.css'), 'utf8').trim();
-      var json = read(path.join('test', 'cases', file + '.json'), 'utf8').trim();
+      var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
+      var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
       var ret = parse(css, { position: true });
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -16,7 +16,7 @@ describe('parse(str)', function(){
     it('should parse ' + file, function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8').trim();
       var json = read(path.join('test', 'cases', file + '.json'), 'utf8').trim();
-      var ret = parse(css);
+      var ret = parse(css, { position: true });
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);
     })


### PR DESCRIPTION
The position now includes the column number. One thing that still bothers me is that for some node types the range from `start` to `end` includes the whitespace _after_ the actual token. We could remove the trailing `\s*` from the regular expressions and call `whitespace()` after invoking `pos()` but the code would get quite ugly.
