### PR TITLE
MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2013 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "CSS parser",
   "keywords": ["css", "parser", "stylesheet"],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "license": "MIT",
   "devDependencies": {
     "mocha": "*",
     "should": "*"


### PR DESCRIPTION
This feels a bit presumptuous, but seeing as you accepted visionmedia/node-github-url-from-git#5, I'm hoping you're amenable to distributing `css-parse` under the MIT license as well.

In case you haven't seen it already, you could also

```
curl -d'{ "copyright": "TJ Holowaychuk" }' http://visionmedia.mit-license.org
```

and then just add the following to your `package.json`

``` js
  "licenses": [
    {
      "type": "MIT",
      "url": "http://visionmedia.mit-license.org/"
    }
  ],
```
