### PR TITLE
Parser now correctly parses attributes with whitespace before colon

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ module.exports = function(css, options){
     // prop
     var prop = match(/^(\*?[-\/\*\w]+)\s*/);
     if (!prop) return;
-    prop = prop[0];
+    prop = prop[0].replace(/^\s+|\s+$/, '');
 
     // :
     if (!match(/^:\s*/)) return error("property missing ':'");

--- a/test/cases/colon-space.css
+++ b/test/cases/colon-space.css
@@ -1,0 +1,4 @@
+a {
+    margin  : auto;
+    padding : 0;
+}

--- a/test/cases/colon-space.json
+++ b/test/cases/colon-space.json
@@ -1,0 +1,55 @@
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "rule",
+        "selectors": [
+          "a"
+        ],
+        "declarations": [
+          {
+            "type": "declaration",
+            "property": "margin",
+            "value": "auto",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 19
+              }
+            }
+          },
+          {
+            "type": "declaration",
+            "property": "padding",
+            "value": "0",
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 5
+              },
+              "end": {
+                "line": 3,
+                "column": 16
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/cases/messed-up.json
+++ b/test/cases/messed-up.json
@@ -10,7 +10,7 @@
         "declarations": [
           {
             "type": "declaration",
-            "property": "foo\n  ",
+            "property": "foo",
             "value": "'bar'",
             "position": {
               "start": {
@@ -91,7 +91,7 @@
         "declarations": [
           {
             "type": "declaration",
-            "property": "foo\n     ",
+            "property": "foo",
             "value": "bar",
             "position": {
               "start": {
@@ -106,7 +106,7 @@
           },
           {
             "type": "declaration",
-            "property": "bar\n     ",
+            "property": "bar",
             "value": "baz",
             "position": {
               "start": {


### PR DESCRIPTION
For rules such as:

``` css
a {
  margin  : auto;
  padding : 0;
}
```

... that contain whitespace before a colon, the CSS attribute name is extracted with the whitespace instead of trimming it. This breaks the case above, which is valid CSS. The added test case and modified expected result are contained in the pull request, including the trimming in `index.js`.

This is a fix I need to fix autoprefixer, which depends on this library for parsing CSS files and applying prefixes where applicable.
