### PR TITLE
Relax keyframe selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ module.exports = function(css, options){
     var pos = position();
 
     // prop
-    var prop = match(/^(\*?[-\/\*\w]+)\s*/);
+    var prop = match(/^(\*?[-\/\*\w]+(\[[0-9a-z_-]+\])?)\s*/);
     if (!prop) return;
     prop = trim(prop[0]);
 
@@ -232,7 +232,7 @@ module.exports = function(css, options){
     var vals = [];
     var pos = position();
 
-    while (m = match(/^(from|to|\d+%|\.\d+%|\d+\.\d+%)\s*/)) {
+    while (m = match(/^((\d+\.\d+|\.\d+|\d+)%{0,1}|[a-z]+)\s*/)) {
       vals.push(m[1]);
       match(/^,\s*/);
     }

--- a/test/cases/keyframes.advanced.css
+++ b/test/cases/keyframes.advanced.css
@@ -1,0 +1,13 @@
+@keyframes advanced {
+  top {
+    opacity[sqrt]: 0;
+  }
+
+  100 {
+    opacity: 0.5;
+  }
+
+  bottom {
+    opacity: 1;
+  }
+}

--- a/test/cases/keyframes.advanced.json
+++ b/test/cases/keyframes.advanced.json
@@ -1,0 +1,122 @@
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "keyframes",
+        "name": "advanced",
+        "keyframes": [
+          {
+            "type": "keyframe",
+            "values": [
+              "top"
+            ],
+            "declarations": [
+              {
+                "type": "declaration",
+                "property": "opacity[sqrt]",
+                "value": "0",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 21
+                  }
+                }
+              }
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 4
+              }
+            }
+          },
+          {
+            "type": "keyframe",
+            "values": [
+              "100"
+            ],
+            "declarations": [
+              {
+                "type": "declaration",
+                "property": "opacity",
+                "value": "0.5",
+                "position": {
+                  "start": {
+                    "line": 7,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 17
+                  }
+                }
+              }
+            ],
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 8,
+                "column": 4
+              }
+            }
+          },
+          {
+            "type": "keyframe",
+            "values": [
+              "bottom"
+            ],
+            "declarations": [
+              {
+                "type": "declaration",
+                "property": "opacity",
+                "value": "1",
+                "position": {
+                  "start": {
+                    "line": 11,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 11,
+                    "column": 15
+                  }
+                }
+              }
+            ],
+            "position": {
+              "start": {
+                "line": 10,
+                "column": 3
+              },
+              "end": {
+                "line": 12,
+                "column": 4
+              }
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 13,
+            "column": 2
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The changes adds the ability to parse basic [Skrollr Stylesheets](https://github.com/Prinzhorn/skrollr-stylesheets).

It allows numerical keyframes-selectors and easing function syntax, eg:

```
@-skrollr-keyframes one {
    top {
        left: 100%;
        opacity[swing]: 0.0;
    }
    100 {
        left: 10%;
        opacity: 0.5;
    }
    bottom {
        left: 0%;
        opacity: 1.0;
    }
}
```
- numerical keyframes-selectors
- `top`, `bottom` keyframes-selectors
- easing function syntax
