### PR TITLE
Performance improvements to atrule() and trim() fns

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,6 +450,8 @@ module.exports = function(css, options){
    */
 
   function atrule() {
+    if (css[0] != '@') return;
+
     return atkeyframes()
       || atmedia()
       || atsupports()
@@ -487,5 +489,5 @@ module.exports = function(css, options){
  */
 
 function trim(str) {
-  return (str || '').replace(/^\s+|\s+$/g, '');
+  return str ? str.replace(/^\s+|\s+$/g, '') : '';
 }


### PR DESCRIPTION
I found a couple tiny (code-wise) perf tweaks with a big impact today.

Before this change, `atrule()` was a cascade of potentially failing RegExps.
This change introduces a short-circuit that bypasses the RegExps if the
next character is not an '@'. `make bench` shows a 20-25% improvement in
op/s.

Also before this change, when the argument is falsy `trim()` calls `replace()`
on the empty string. This change guards against unnecessary calls to `replace()`
with a ternary. `make bench` shows a 2.5-5.5% improvement in op/s.

With both changes, make bench shows a combined 30-40% improvement.

Benchmarks were run 5 times and the results averaged.
