### PR TITLE
allow hash symbol in property name

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ module.exports = function(css, options){
     var pos = position();
 
     // prop
-    var prop = match(/^(\*?[-\/\*\w]+(\[[0-9a-z_-]+\])?)\s*/);
+    var prop = match(/^(\*?[-#\/\*\w]+(\[[0-9a-z_-]+\])?)\s*/);
     if (!prop) return;
     prop = trim(prop[0]);
 

--- a/test/cases/wtf.css
+++ b/test/cases/wtf.css
@@ -1,4 +1,5 @@
 .wtf {
   *overflow-x: hidden;
   //max-height: 110px;
+  #height: 18px;
 }

--- a/test/cases/wtf.json
+++ b/test/cases/wtf.json
@@ -39,6 +39,22 @@
               },
               "source": "wtf.css"
             }
+          },
+          {
+            "type": "declaration",
+            "property": "#height",
+            "value": "18px",
+            "position": {
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 16
+              },
+              "source": "wtf.css"
+            }
           }
         ],
         "position": {
@@ -47,7 +63,7 @@
             "column": 1
           },
           "end": {
-            "line": 4,
+            "line": 5,
             "column": 2
           },
           "source": "wtf.css"


### PR DESCRIPTION
Hi.This one makes a parser be more loyal to the properties which contains a hash symbol in the name. Usually it is an IE hacks like

``` css
.sample {
   height: 15px;
   #height: 15px;
   _height: 21px;
}
```
