### PR TITLE
Add option for nested CSS rules.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -125,6 +125,47 @@ parse tree with `.position` enabled:
 }
 ```
 
+set `.nested` to allow rule nesting:
+
+```css
+div {
+  & a {
+    color: blue;
+  }
+}
+```
+
+```json
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "rule",
+        "selectors": [
+          "div"
+        ],
+        "declarations": [
+          {
+            "type": "nested",
+            "selectors": [
+              "& a"
+            ],
+            "declarations": [
+              {
+                "type": "declaration",
+                "property": "color",
+                "value": "blue"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 If you also pass in `source: 'path/to/original.css'`, that will be set
 on `node.position.source`.
 
@@ -133,9 +174,9 @@ on `node.position.source`.
   Parsed 15,000 lines of CSS (2mb) in 40ms on my macbook air.
 
 ## Related
- 
-  [css-stringify](https://github.com/visionmedia/css-stringify "CSS-Stringify")  
-  [css-value](https://github.com/visionmedia/css-value "CSS-Value")  
+
+  [css-stringify](https://github.com/visionmedia/css-stringify "CSS-Stringify")
+  [css-value](https://github.com/visionmedia/css-value "CSS-Value")
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ module.exports = function(css, options){
    * Parse nested rule.
    */
   function nested() {
-    if (!css.match(/^[^{}]+\s+{/)) return;
+    if (options.nested !== true || !css.match(/^[^{}]+\s+{/)) return;
 
     var pos = position();
     var sel = selector();

--- a/index.js
+++ b/index.js
@@ -170,7 +170,28 @@ module.exports = function(css, options){
   function selector() {
     var m = match(/^([^{]+)/);
     if (!m) return;
+
     return trim(m[0]).split(/\s*,\s*/);
+  }
+
+  /**
+   * Parse nested rule.
+   */
+  function nested() {
+    if (!css.match(/^[^{}]+\s+{/)) return;
+
+    var pos = position();
+    var sel = selector();
+
+    sel.map(function (selNested) {
+      if (selNested.charAt(0) !== '&') return error("nested selector missing '&' prefix");
+    });
+
+    return pos({
+      type: 'nested',
+      selectors: sel,
+      declarations: declarations()
+    });
   }
 
   /**
@@ -178,6 +199,9 @@ module.exports = function(css, options){
    */
 
   function declaration() {
+    var nest = nested();
+    if (nest) return nest;
+
     var pos = position();
 
     // prop

--- a/test/cases/nested.css
+++ b/test/cases/nested.css
@@ -1,0 +1,11 @@
+div {
+  & a, & span.link {
+    color: black;
+  }
+
+  & a {
+    &:hover {
+      color: blue;
+    }
+  }
+}

--- a/test/cases/nested.json
+++ b/test/cases/nested.json
@@ -1,0 +1,116 @@
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "rule",
+        "selectors": [
+          "div"
+        ],
+        "declarations": [
+          {
+            "type": "nested",
+            "selectors": [
+              "& a",
+              "& span.link"
+            ],
+            "declarations": [
+              {
+                "type": "declaration",
+                "property": "color",
+                "value": "black",
+                "position": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 17
+                  },
+                  "source": "nested.css"
+                }
+              }
+            ],
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 4
+              },
+              "source": "nested.css"
+            }
+          },
+          {
+            "type": "nested",
+            "selectors": [
+              "& a"
+            ],
+            "declarations": [
+              {
+                "type": "nested",
+                "selectors": [
+                  "&:hover"
+                ],
+                "declarations": [
+                  {
+                    "type": "declaration",
+                    "property": "color",
+                    "value": "blue",
+                    "position": {
+                      "start": {
+                        "line": 8,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 18
+                      },
+                      "source": "nested.css"
+                    }
+                  }
+                ],
+                "position": {
+                  "start": {
+                    "line": 7,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 6
+                  },
+                  "source": "nested.css"
+                }
+              }
+            ],
+            "position": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 10,
+                "column": 4
+              },
+              "source": "nested.css"
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 11,
+            "column": 2
+          },
+          "source": "nested.css"
+        }
+      }
+    ]
+  }
+}

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -15,8 +15,8 @@ describe('parse(str)', function(){
     file = path.basename(file, '.css');
     it('should parse ' + file, function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
-      var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
-      var ret = parse(css, { position: true, source: file + '.css' });
+      var json = read(path.join('test', 'cases', file + '.json'), 'utf8').trim();
+      var ret = parse(css, { position: true, source: file + '.css', nested: true });
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);
     })


### PR DESCRIPTION
Yes, it's not a part of the CSS spec, but it's a common enough feature in CSS preprocessors that I feel it has a place in `css-parse`. Because it's non-standard, I defaulted the feature to be disabled unless the `nested` option is set to `true`.
