### PR TITLE
fixed parsing error when input broken comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function(css, options){
     if ('/' != css.charAt(0) || '*' != css.charAt(1)) return;
 
     var i = 2;
-    while (null != css.charAt(i) && ('*' != css.charAt(i) || '/' != css.charAt(i + 1))) ++i;
+    while ('' !== css.charAt(i) && ('*' != css.charAt(i) || '/' != css.charAt(i + 1))) ++i;
     i += 2;
 
     var str = css.slice(2, i - 2);


### PR DESCRIPTION
String.prototyp.charAt do not return Null.
Return char(String) or empty string ""

```
var css = require('css');
css.parse('/* comments'); // While loop can not stop
```
