### PR TITLE
Source map fixes

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
  * changed default `options.position` value to `true`
  * remove comments from properties and values
  * asserts when selectors are missing
+ * added `node.position.content` property
 
 1.7.0 / 2013-12-21
 ==================

--- a/History.md
+++ b/History.md
@@ -1,10 +1,6 @@
-
 2.0.0 / 2014-01-24
 ==================
 
- * rename source to filename
-   - `source` is now the CSS string
-   - `filename` is now the optional filename
  * changed default `options.position` value to `true`
  * remove comments from properties and values
  * asserts when selectors are missing

--- a/Readme.md
+++ b/Readme.md
@@ -16,8 +16,8 @@ var css = "body { \n background-color: #fff;\n }";
 
 var output_obj = parse(css);
 
-// Filename parameter for source mapping
-var output_obj_pos = parse(css, { filename: 'file.css' });
+// Source parameter to specify source file name for source maps
+var output_obj_pos = parse(css, { source: 'file.css' });
 
 // Print parsed object as CSS string
 console.log(JSON.stringify(output_obj, null, 2));
@@ -145,17 +145,17 @@ parse tree with `.position` enabled:
 }
 ```
 
-If you also pass in `filename: 'path/to/original.css'`, that will be set
-on `node.position.filename`.
+If you also pass in `source: 'path/to/original.css'`, that will be set
+on `node.position.source`.
 
 ## Performance
 
   Parsed 15,000 lines of CSS (2mb) in 40ms on my macbook air.
 
 ## Related
-
-  [css-stringify](https://github.com/visionmedia/css-stringify "CSS-Stringify")
-  [css-value](https://github.com/visionmedia/css-value "CSS-Value")
+ 
+  [css-stringify](https://github.com/visionmedia/css-stringify "CSS-Stringify")  
+  [css-value](https://github.com/visionmedia/css-value "CSS-Value")  
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ console.log(JSON.stringify(output_obj, null, 2));
 
 `options`:
 
-- `filename` - recommended for debugging.
+- `source` - recommended for debugging.
 - `position` - `true` by default.
 
 ### Errors
@@ -39,8 +39,7 @@ Errors will have `err.position` where `position` is:
 
 - `start` - start line and column numbers
 - `end` - end line and column numbers
-- `filename` - filename if passed to options
-- `source` - source CSS string
+- `source` - `options.source` if passed to options
 
 If you create any errors in plugins such as in [rework](https://github.com/reworkcss/rework), you __must__ set the `position` as well for consistency.
 

--- a/Readme.md
+++ b/Readme.md
@@ -144,8 +144,9 @@ parse tree with `.position` enabled:
 }
 ```
 
-If you also pass in `source: 'path/to/original.css'`, that will be set
-on `node.position.source`.
+`node.position.content` is set on each node to the full source string. If you
+also pass in `source: 'path/to/original.css'`, that will be set on
+`node.position.source`.
 
 ## Performance
 

--- a/index.js
+++ b/index.js
@@ -33,16 +33,27 @@ module.exports = function(css, options){
     if (!options.position) return positionNoop;
 
     return function(node){
-      node.position = {
-        start: start,
-        end: { line: lineno, column: column },
-        source: options.source
-      };
-
+      node.position = new Position(start);
       whitespace();
       return node;
     };
   }
+
+  /**
+   * Store position information for a node
+   */
+
+  function Position(start) {
+    this.start = start;
+    this.end = { line: lineno, column: column };
+    this.source = options.source;
+  }
+
+  /**
+   * Non-enumerable source string
+   */
+
+  Position.prototype.content = css;
 
   /**
    * Return `node`.

--- a/index.js
+++ b/index.js
@@ -29,28 +29,20 @@ module.exports = function(css, options){
    */
 
   function position() {
+    var start = { line: lineno, column: column };
     if (!options.position) return positionNoop;
 
-    var start = { line: lineno, column: column };
-
     return function(node){
-      node.position = new Position(start);
+      node.position = {
+        start: start,
+        end: { line: lineno, column: column },
+        source: options.source
+      };
+
       whitespace();
       return node;
     };
   }
-
-  function Position(start) {
-    this.start = start;
-    this.end = { line: lineno, column: column };
-    this.filename = options.filename;
-  }
-
-  /**
-   * Non-enumerable source string.
-   */
-
-  Position.prototype.source = css;
 
   /**
    * Return `node`.
@@ -65,9 +57,12 @@ module.exports = function(css, options){
    * Error `msg`.
    */
 
-  function error(msg, start) {
+  function error(msg) {
     var err = new Error(msg + ' near line ' + lineno + ':' + column);
-    err.position = new Position(start);
+    err.filename = options.source;
+    err.line = lineno;
+    err.column = column;
+    err.source = css;
     throw err;
   }
 
@@ -183,7 +178,7 @@ module.exports = function(css, options){
   function selector() {
     var m = match(/^([^{]+)/);
     if (!m) return;
-    /* @fix Remove all comments from selectors
+    /* @fix Remove all comments from selectors 
      * http://ostermiller.org/findcomment.html */
     return trim(m[0]).replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '').split(/\s*,\s*/);
   }

--- a/test/cases/charset.json
+++ b/test/cases/charset.json
@@ -14,7 +14,7 @@
             "line": 1,
             "column": 18
           },
-          "filename": "charset.css"
+          "source": "charset.css"
         }
       },
       {
@@ -29,7 +29,7 @@
             "line": 1,
             "column": 82
           },
-          "filename": "charset.css"
+          "source": "charset.css"
         }
       },
       {
@@ -44,7 +44,7 @@
             "line": 2,
             "column": 24
           },
-          "filename": "charset.css"
+          "source": "charset.css"
         }
       },
       {
@@ -59,7 +59,7 @@
             "line": 2,
             "column": 122
           },
-          "filename": "charset.css"
+          "source": "charset.css"
         }
       }
     ]

--- a/test/cases/colon-space.json
+++ b/test/cases/colon-space.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 19
               },
-              "filename": "colon-space.css"
+              "source": "colon-space.css"
             }
           },
           {
@@ -37,7 +37,7 @@
                 "line": 3,
                 "column": 16
               },
-              "filename": "colon-space.css"
+              "source": "colon-space.css"
             }
           }
         ],
@@ -50,7 +50,7 @@
             "line": 4,
             "column": 2
           },
-          "filename": "colon-space.css"
+          "source": "colon-space.css"
         }
       }
     ]

--- a/test/cases/comment.in.json
+++ b/test/cases/comment.in.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 20
               },
-              "filename": "comment.in.css"
+              "source": "comment.in.css"
             }
           },
           {
@@ -37,7 +37,7 @@
                 "line": 3,
                 "column": 51
               },
-              "filename": "comment.in.css"
+              "source": "comment.in.css"
             }
           }
         ],
@@ -50,7 +50,7 @@
             "line": 4,
             "column": 2
           },
-          "filename": "comment.in.css"
+          "source": "comment.in.css"
         }
       }
     ]

--- a/test/cases/comment.json
+++ b/test/cases/comment.json
@@ -14,7 +14,7 @@
             "line": 1,
             "column": 8
           },
-          "filename": "comment.css"
+          "source": "comment.css"
         }
       },
       {
@@ -36,7 +36,7 @@
                 "line": 3,
                 "column": 44
               },
-              "filename": "comment.css"
+              "source": "comment.css"
             }
           },
           {
@@ -51,7 +51,7 @@
                 "line": 4,
                 "column": 10
               },
-              "filename": "comment.css"
+              "source": "comment.css"
             }
           },
           {
@@ -66,7 +66,7 @@
                 "line": 5,
                 "column": 7
               },
-              "filename": "comment.css"
+              "source": "comment.css"
             }
           },
           {
@@ -82,7 +82,7 @@
                 "line": 5,
                 "column": 17
               },
-              "filename": "comment.css"
+              "source": "comment.css"
             }
           },
           {
@@ -97,7 +97,7 @@
                 "line": 6,
                 "column": 10
               },
-              "filename": "comment.css"
+              "source": "comment.css"
             }
           }
         ],
@@ -110,7 +110,7 @@
             "line": 7,
             "column": 2
           },
-          "filename": "comment.css"
+          "source": "comment.css"
         }
       },
       {
@@ -125,7 +125,7 @@
             "line": 7,
             "column": 10
           },
-          "filename": "comment.css"
+          "source": "comment.css"
         }
       },
       {
@@ -140,7 +140,7 @@
             "line": 9,
             "column": 8
           },
-          "filename": "comment.css"
+          "source": "comment.css"
         }
       }
     ]

--- a/test/cases/comment.url.json
+++ b/test/cases/comment.url.json
@@ -14,7 +14,7 @@
             "line": 1,
             "column": 34
           },
-          "filename": "comment.url.css"
+          "source": "comment.url.css"
         }
       },
       {
@@ -29,7 +29,7 @@
             "line": 2,
             "column": 5
           },
-          "filename": "comment.url.css"
+          "source": "comment.url.css"
         }
       },
       {
@@ -50,7 +50,7 @@
                 "line": 4,
                 "column": 12
               },
-              "filename": "comment.url.css"
+              "source": "comment.url.css"
             }
           },
           {
@@ -65,7 +65,7 @@
                 "line": 5,
                 "column": 18
               },
-              "filename": "comment.url.css"
+              "source": "comment.url.css"
             }
           },
           {
@@ -81,7 +81,7 @@
                 "line": 6,
                 "column": 11
               },
-              "filename": "comment.url.css"
+              "source": "comment.url.css"
             }
           },
           {
@@ -96,7 +96,7 @@
                 "line": 6,
                 "column": 46
               },
-              "filename": "comment.url.css"
+              "source": "comment.url.css"
             }
           }
         ],
@@ -109,7 +109,7 @@
             "line": 7,
             "column": 2
           },
-          "filename": "comment.url.css"
+          "source": "comment.url.css"
         }
       }
     ]

--- a/test/cases/document.json
+++ b/test/cases/document.json
@@ -19,7 +19,7 @@
                 "line": 2,
                 "column": 17
               },
-              "filename": "document.css"
+              "source": "document.css"
             }
           },
           {
@@ -40,7 +40,7 @@
                     "line": 4,
                     "column": 20
                   },
-                  "filename": "document.css"
+                  "source": "document.css"
                 }
               },
               {
@@ -56,7 +56,7 @@
                     "line": 6,
                     "column": 3
                   },
-                  "filename": "document.css"
+                  "source": "document.css"
                 }
               }
             ],
@@ -69,7 +69,7 @@
                 "line": 6,
                 "column": 4
               },
-              "filename": "document.css"
+              "source": "document.css"
             }
           }
         ],
@@ -82,7 +82,7 @@
             "line": 7,
             "column": 2
           },
-          "filename": "document.css"
+          "source": "document.css"
         }
       }
     ]

--- a/test/cases/escapes.json
+++ b/test/cases/escapes.json
@@ -14,7 +14,7 @@
             "line": 1,
             "column": 40
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -29,7 +29,7 @@
             "line": 2,
             "column": 48
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -44,7 +44,7 @@
             "line": 3,
             "column": 43
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -62,7 +62,7 @@
             "line": 4,
             "column": 12
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -77,7 +77,7 @@
             "line": 5,
             "column": 46
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -95,7 +95,7 @@
             "line": 6,
             "column": 13
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -110,7 +110,7 @@
             "line": 7,
             "column": 48
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -128,7 +128,7 @@
             "line": 8,
             "column": 13
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -143,7 +143,7 @@
             "line": 9,
             "column": 43
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -161,7 +161,7 @@
             "line": 10,
             "column": 8
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -176,7 +176,7 @@
             "line": 11,
             "column": 47
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -194,7 +194,7 @@
             "line": 12,
             "column": 11
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -209,7 +209,7 @@
             "line": 13,
             "column": 41
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -227,7 +227,7 @@
             "line": 14,
             "column": 5
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -242,7 +242,7 @@
             "line": 15,
             "column": 60
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -264,7 +264,7 @@
                 "line": 16,
                 "column": 26
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -277,7 +277,7 @@
             "line": 16,
             "column": 28
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -299,7 +299,7 @@
                 "line": 17,
                 "column": 26
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -312,7 +312,7 @@
             "line": 17,
             "column": 28
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -334,7 +334,7 @@
                 "line": 18,
                 "column": 43
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           },
           {
@@ -350,7 +350,7 @@
                 "line": 18,
                 "column": 56
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -363,7 +363,7 @@
             "line": 18,
             "column": 58
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -385,7 +385,7 @@
                 "line": 19,
                 "column": 21
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -398,7 +398,7 @@
             "line": 19,
             "column": 23
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -420,7 +420,7 @@
                 "line": 20,
                 "column": 19
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -433,7 +433,7 @@
             "line": 20,
             "column": 21
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -455,7 +455,7 @@
                 "line": 21,
                 "column": 19
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -468,7 +468,7 @@
             "line": 21,
             "column": 21
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -490,7 +490,7 @@
                 "line": 22,
                 "column": 22
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -503,7 +503,7 @@
             "line": 22,
             "column": 24
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -525,7 +525,7 @@
                 "line": 23,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -538,7 +538,7 @@
             "line": 23,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -560,7 +560,7 @@
                 "line": 24,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -573,7 +573,7 @@
             "line": 24,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -595,7 +595,7 @@
                 "line": 25,
                 "column": 24
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -608,7 +608,7 @@
             "line": 25,
             "column": 26
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -630,7 +630,7 @@
                 "line": 26,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -643,7 +643,7 @@
             "line": 26,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -665,7 +665,7 @@
                 "line": 27,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -678,7 +678,7 @@
             "line": 27,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -700,7 +700,7 @@
                 "line": 28,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -713,7 +713,7 @@
             "line": 28,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -735,7 +735,7 @@
                 "line": 29,
                 "column": 24
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -748,7 +748,7 @@
             "line": 29,
             "column": 26
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -770,7 +770,7 @@
                 "line": 30,
                 "column": 26
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -783,7 +783,7 @@
             "line": 30,
             "column": 28
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -805,7 +805,7 @@
                 "line": 31,
                 "column": 24
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -818,7 +818,7 @@
             "line": 31,
             "column": 26
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -840,7 +840,7 @@
                 "line": 32,
                 "column": 27
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -853,7 +853,7 @@
             "line": 32,
             "column": 29
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -875,7 +875,7 @@
                 "line": 33,
                 "column": 23
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -888,7 +888,7 @@
             "line": 33,
             "column": 25
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -910,7 +910,7 @@
                 "line": 34,
                 "column": 36
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -923,7 +923,7 @@
             "line": 34,
             "column": 38
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -945,7 +945,7 @@
                 "line": 35,
                 "column": 240
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -958,7 +958,7 @@
             "line": 35,
             "column": 242
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -980,7 +980,7 @@
                 "line": 36,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -993,7 +993,7 @@
             "line": 36,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1015,7 +1015,7 @@
                 "line": 37,
                 "column": 22
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1028,7 +1028,7 @@
             "line": 37,
             "column": 24
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1050,7 +1050,7 @@
                 "line": 38,
                 "column": 28
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1063,7 +1063,7 @@
             "line": 38,
             "column": 30
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1085,7 +1085,7 @@
                 "line": 39,
                 "column": 20
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1098,7 +1098,7 @@
             "line": 39,
             "column": 22
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1120,7 +1120,7 @@
                 "line": 40,
                 "column": 31
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1133,7 +1133,7 @@
             "line": 40,
             "column": 33
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1155,7 +1155,7 @@
                 "line": 41,
                 "column": 26
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1168,7 +1168,7 @@
             "line": 41,
             "column": 28
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1190,7 +1190,7 @@
                 "line": 42,
                 "column": 27
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1203,7 +1203,7 @@
             "line": 42,
             "column": 29
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1225,7 +1225,7 @@
                 "line": 43,
                 "column": 46
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1238,7 +1238,7 @@
             "line": 43,
             "column": 48
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1260,7 +1260,7 @@
                 "line": 44,
                 "column": 33
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1273,7 +1273,7 @@
             "line": 44,
             "column": 35
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1295,7 +1295,7 @@
                 "line": 45,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1308,7 +1308,7 @@
             "line": 45,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1330,7 +1330,7 @@
                 "line": 46,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1343,7 +1343,7 @@
             "line": 46,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1365,7 +1365,7 @@
                 "line": 47,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1378,7 +1378,7 @@
             "line": 47,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1400,7 +1400,7 @@
                 "line": 48,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1413,7 +1413,7 @@
             "line": 48,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1435,7 +1435,7 @@
                 "line": 49,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1448,7 +1448,7 @@
             "line": 49,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1470,7 +1470,7 @@
                 "line": 50,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1483,7 +1483,7 @@
             "line": 50,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1505,7 +1505,7 @@
                 "line": 51,
                 "column": 25
               },
-              "filename": "escapes.css"
+              "source": "escapes.css"
             }
           }
         ],
@@ -1518,7 +1518,7 @@
             "line": 51,
             "column": 27
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1533,7 +1533,7 @@
             "line": 53,
             "column": 44
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       },
       {
@@ -1548,7 +1548,7 @@
             "line": 54,
             "column": 28
           },
-          "filename": "escapes.css"
+          "source": "escapes.css"
         }
       }
     ]

--- a/test/cases/host.json
+++ b/test/cases/host.json
@@ -24,7 +24,7 @@
                     "line": 3,
                     "column": 19
                   },
-                  "filename": "host.css"
+                  "source": "host.css"
                 }
               }
             ],
@@ -37,7 +37,7 @@
                 "line": 4,
                 "column": 4
               },
-              "filename": "host.css"
+              "source": "host.css"
             }
           }
         ],
@@ -50,7 +50,7 @@
             "line": 5,
             "column": 2
           },
-          "filename": "host.css"
+          "source": "host.css"
         }
       }
     ]

--- a/test/cases/import.json
+++ b/test/cases/import.json
@@ -14,7 +14,7 @@
             "line": 2,
             "column": 36
           },
-          "filename": "import.css"
+          "source": "import.css"
         }
       },
       {
@@ -29,7 +29,7 @@
             "line": 3,
             "column": 42
           },
-          "filename": "import.css"
+          "source": "import.css"
         }
       },
       {
@@ -44,7 +44,7 @@
             "line": 4,
             "column": 22
           },
-          "filename": "import.css"
+          "source": "import.css"
         }
       },
       {
@@ -59,7 +59,7 @@
             "line": 5,
             "column": 41
           },
-          "filename": "import.css"
+          "source": "import.css"
         }
       },
       {
@@ -74,7 +74,7 @@
             "line": 6,
             "column": 65
           },
-          "filename": "import.css"
+          "source": "import.css"
         }
       }
     ]

--- a/test/cases/import.messed.json
+++ b/test/cases/import.messed.json
@@ -14,7 +14,7 @@
             "line": 2,
             "column": 39
           },
-          "filename": "import.messed.css"
+          "source": "import.messed.css"
         }
       },
       {
@@ -29,7 +29,7 @@
             "line": 3,
             "column": 44
           },
-          "filename": "import.messed.css"
+          "source": "import.messed.css"
         }
       },
       {
@@ -44,7 +44,7 @@
             "line": 4,
             "column": 28
           },
-          "filename": "import.messed.css"
+          "source": "import.messed.css"
         }
       },
       {
@@ -59,7 +59,7 @@
             "line": 5,
             "column": 45
           },
-          "filename": "import.messed.css"
+          "source": "import.messed.css"
         }
       },
       {
@@ -74,7 +74,7 @@
             "line": 7,
             "column": 67
           },
-          "filename": "import.messed.css"
+          "source": "import.messed.css"
         }
       }
     ]

--- a/test/cases/keyframes.advanced.json
+++ b/test/cases/keyframes.advanced.json
@@ -25,7 +25,7 @@
                     "line": 3,
                     "column": 21
                   },
-                  "filename": "keyframes.advanced.css"
+                  "source": "keyframes.advanced.css"
                 }
               }
             ],
@@ -38,7 +38,7 @@
                 "line": 4,
                 "column": 4
               },
-              "filename": "keyframes.advanced.css"
+              "source": "keyframes.advanced.css"
             }
           },
           {
@@ -60,7 +60,7 @@
                     "line": 7,
                     "column": 17
                   },
-                  "filename": "keyframes.advanced.css"
+                  "source": "keyframes.advanced.css"
                 }
               }
             ],
@@ -73,7 +73,7 @@
                 "line": 8,
                 "column": 4
               },
-              "filename": "keyframes.advanced.css"
+              "source": "keyframes.advanced.css"
             }
           },
           {
@@ -95,7 +95,7 @@
                     "line": 11,
                     "column": 15
                   },
-                  "filename": "keyframes.advanced.css"
+                  "source": "keyframes.advanced.css"
                 }
               }
             ],
@@ -108,7 +108,7 @@
                 "line": 12,
                 "column": 4
               },
-              "filename": "keyframes.advanced.css"
+              "source": "keyframes.advanced.css"
             }
           }
         ],
@@ -121,7 +121,7 @@
             "line": 13,
             "column": 2
           },
-          "filename": "keyframes.advanced.css"
+          "source": "keyframes.advanced.css"
         }
       }
     ]

--- a/test/cases/keyframes.complex.json
+++ b/test/cases/keyframes.complex.json
@@ -25,7 +25,7 @@
                     "line": 2,
                     "column": 14
                   },
-                  "filename": "keyframes.complex.css"
+                  "source": "keyframes.complex.css"
                 }
               },
               {
@@ -41,7 +41,7 @@
                     "line": 2,
                     "column": 24
                   },
-                  "filename": "keyframes.complex.css"
+                  "source": "keyframes.complex.css"
                 }
               }
             ],
@@ -54,7 +54,7 @@
                 "line": 2,
                 "column": 25
               },
-              "filename": "keyframes.complex.css"
+              "source": "keyframes.complex.css"
             }
           },
           {
@@ -76,7 +76,7 @@
                     "line": 3,
                     "column": 22
                   },
-                  "filename": "keyframes.complex.css"
+                  "source": "keyframes.complex.css"
                 }
               }
             ],
@@ -89,7 +89,7 @@
                 "line": 3,
                 "column": 23
               },
-              "filename": "keyframes.complex.css"
+              "source": "keyframes.complex.css"
             }
           },
           {
@@ -113,7 +113,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "filename": "keyframes.complex.css"
+                  "source": "keyframes.complex.css"
                 }
               }
             ],
@@ -126,7 +126,7 @@
                 "line": 6,
                 "column": 27
               },
-              "filename": "keyframes.complex.css"
+              "source": "keyframes.complex.css"
             }
           },
           {
@@ -148,7 +148,7 @@
                     "line": 7,
                     "column": 20
                   },
-                  "filename": "keyframes.complex.css"
+                  "source": "keyframes.complex.css"
                 }
               },
               {
@@ -164,7 +164,7 @@
                     "line": 7,
                     "column": 33
                   },
-                  "filename": "keyframes.complex.css"
+                  "source": "keyframes.complex.css"
                 }
               }
             ],
@@ -177,7 +177,7 @@
                 "line": 7,
                 "column": 34
               },
-              "filename": "keyframes.complex.css"
+              "source": "keyframes.complex.css"
             }
           }
         ],
@@ -190,7 +190,7 @@
             "line": 8,
             "column": 2
           },
-          "filename": "keyframes.complex.css"
+          "source": "keyframes.complex.css"
         }
       }
     ]

--- a/test/cases/keyframes.json
+++ b/test/cases/keyframes.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 19
               },
-              "filename": "keyframes.css"
+              "source": "keyframes.css"
             }
           },
           {
@@ -39,7 +39,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "filename": "keyframes.css"
+                  "source": "keyframes.css"
                 }
               },
               {
@@ -55,7 +55,7 @@
                     "line": 5,
                     "column": 15
                   },
-                  "filename": "keyframes.css"
+                  "source": "keyframes.css"
                 }
               }
             ],
@@ -68,7 +68,7 @@
                 "line": 6,
                 "column": 4
               },
-              "filename": "keyframes.css"
+              "source": "keyframes.css"
             }
           },
           {
@@ -83,7 +83,7 @@
                 "line": 8,
                 "column": 17
               },
-              "filename": "keyframes.css"
+              "source": "keyframes.css"
             }
           },
           {
@@ -104,7 +104,7 @@
                     "line": 10,
                     "column": 20
                   },
-                  "filename": "keyframes.css"
+                  "source": "keyframes.css"
                 }
               },
               {
@@ -120,7 +120,7 @@
                     "line": 11,
                     "column": 15
                   },
-                  "filename": "keyframes.css"
+                  "source": "keyframes.css"
                 }
               }
             ],
@@ -133,7 +133,7 @@
                 "line": 12,
                 "column": 4
               },
-              "filename": "keyframes.css"
+              "source": "keyframes.css"
             }
           }
         ],
@@ -146,7 +146,7 @@
             "line": 13,
             "column": 2
           },
-          "filename": "keyframes.css"
+          "source": "keyframes.css"
         }
       }
     ]

--- a/test/cases/keyframes.messed.json
+++ b/test/cases/keyframes.messed.json
@@ -25,7 +25,7 @@
                     "line": 2,
                     "column": 14
                   },
-                  "filename": "keyframes.messed.css"
+                  "source": "keyframes.messed.css"
                 }
               }
             ],
@@ -38,7 +38,7 @@
                 "line": 3,
                 "column": 7
               },
-              "filename": "keyframes.messed.css"
+              "source": "keyframes.messed.css"
             }
           },
           {
@@ -60,7 +60,7 @@
                     "line": 6,
                     "column": 16
                   },
-                  "filename": "keyframes.messed.css"
+                  "source": "keyframes.messed.css"
                 }
               }
             ],
@@ -73,7 +73,7 @@
                 "line": 6,
                 "column": 18
               },
-              "filename": "keyframes.messed.css"
+              "source": "keyframes.messed.css"
             }
           }
         ],
@@ -86,7 +86,7 @@
             "line": 6,
             "column": 19
           },
-          "filename": "keyframes.messed.css"
+          "source": "keyframes.messed.css"
         }
       }
     ]

--- a/test/cases/keyframes.vendor.json
+++ b/test/cases/keyframes.vendor.json
@@ -26,7 +26,7 @@
                     "line": 2,
                     "column": 21
                   },
-                  "filename": "keyframes.vendor.css"
+                  "source": "keyframes.vendor.css"
                 }
               }
             ],
@@ -39,7 +39,7 @@
                 "line": 2,
                 "column": 22
               },
-              "filename": "keyframes.vendor.css"
+              "source": "keyframes.vendor.css"
             }
           },
           {
@@ -61,7 +61,7 @@
                     "line": 3,
                     "column": 19
                   },
-                  "filename": "keyframes.vendor.css"
+                  "source": "keyframes.vendor.css"
                 }
               }
             ],
@@ -74,7 +74,7 @@
                 "line": 3,
                 "column": 20
               },
-              "filename": "keyframes.vendor.css"
+              "source": "keyframes.vendor.css"
             }
           }
         ],
@@ -87,7 +87,7 @@
             "line": 4,
             "column": 2
           },
-          "filename": "keyframes.vendor.css"
+          "source": "keyframes.vendor.css"
         }
       }
     ]

--- a/test/cases/media.json
+++ b/test/cases/media.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 19
               },
-              "filename": "media.css"
+              "source": "media.css"
             }
           },
           {
@@ -39,7 +39,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               },
               {
@@ -55,7 +55,7 @@
                     "line": 5,
                     "column": 24
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               },
               {
@@ -71,7 +71,7 @@
                     "line": 6,
                     "column": 16
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               }
             ],
@@ -84,7 +84,7 @@
                 "line": 7,
                 "column": 4
               },
-              "filename": "media.css"
+              "source": "media.css"
             }
           },
           {
@@ -99,7 +99,7 @@
                 "line": 9,
                 "column": 19
               },
-              "filename": "media.css"
+              "source": "media.css"
             }
           },
           {
@@ -120,7 +120,7 @@
                     "line": 11,
                     "column": 22
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               },
               {
@@ -136,7 +136,7 @@
                     "line": 12,
                     "column": 20
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               },
               {
@@ -152,7 +152,7 @@
                     "line": 13,
                     "column": 19
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               }
             ],
@@ -165,7 +165,7 @@
                 "line": 14,
                 "column": 4
               },
-              "filename": "media.css"
+              "source": "media.css"
             }
           }
         ],
@@ -178,7 +178,7 @@
             "line": 15,
             "column": 2
           },
-          "filename": "media.css"
+          "source": "media.css"
         }
       },
       {
@@ -204,7 +204,7 @@
                     "line": 19,
                     "column": 21
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               },
               {
@@ -220,7 +220,7 @@
                     "line": 20,
                     "column": 16
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               }
             ],
@@ -233,7 +233,7 @@
                 "line": 21,
                 "column": 4
               },
-              "filename": "media.css"
+              "source": "media.css"
             }
           },
           {
@@ -255,7 +255,7 @@
                     "line": 23,
                     "column": 17
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               },
               {
@@ -271,7 +271,7 @@
                     "line": 24,
                     "column": 29
                   },
-                  "filename": "media.css"
+                  "source": "media.css"
                 }
               }
             ],
@@ -284,7 +284,7 @@
                 "line": 25,
                 "column": 4
               },
-              "filename": "media.css"
+              "source": "media.css"
             }
           }
         ],
@@ -297,7 +297,7 @@
             "line": 26,
             "column": 2
           },
-          "filename": "media.css"
+          "source": "media.css"
         }
       }
     ]

--- a/test/cases/media.messed.json
+++ b/test/cases/media.messed.json
@@ -25,7 +25,7 @@
                     "line": 4,
                     "column": 20
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               },
               {
@@ -41,7 +41,7 @@
                     "line": 5,
                     "column": 15
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               }
             ],
@@ -54,7 +54,7 @@
                 "line": 6,
                 "column": 4
               },
-              "filename": "media.messed.css"
+              "source": "media.messed.css"
             }
           },
           {
@@ -76,7 +76,7 @@
                     "line": 10,
                     "column": 20
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               },
               {
@@ -92,7 +92,7 @@
                     "line": 11,
                     "column": 19
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               }
             ],
@@ -105,7 +105,7 @@
                 "line": 14,
                 "column": 2
               },
-              "filename": "media.messed.css"
+              "source": "media.messed.css"
             }
           }
         ],
@@ -118,7 +118,7 @@
             "line": 15,
             "column": 4
           },
-          "filename": "media.messed.css"
+          "source": "media.messed.css"
         }
       },
       {
@@ -144,7 +144,7 @@
                     "line": 20,
                     "column": 31
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               },
               {
@@ -160,7 +160,7 @@
                     "line": 21,
                     "column": 26
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               }
             ],
@@ -173,7 +173,7 @@
                 "line": 22,
                 "column": 16
               },
-              "filename": "media.messed.css"
+              "source": "media.messed.css"
             }
           },
           {
@@ -195,7 +195,7 @@
                     "line": 24,
                     "column": 27
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               },
               {
@@ -211,7 +211,7 @@
                     "line": 25,
                     "column": 39
                   },
-                  "filename": "media.messed.css"
+                  "source": "media.messed.css"
                 }
               }
             ],
@@ -224,7 +224,7 @@
                 "line": 26,
                 "column": 16
               },
-              "filename": "media.messed.css"
+              "source": "media.messed.css"
             }
           }
         ],
@@ -237,7 +237,7 @@
             "line": 27,
             "column": 2
           },
-          "filename": "media.messed.css"
+          "source": "media.messed.css"
         }
       }
     ]

--- a/test/cases/messed-up.json
+++ b/test/cases/messed-up.json
@@ -21,7 +21,7 @@
                 "line": 3,
                 "column": 9
               },
-              "filename": "messed-up.css"
+              "source": "messed-up.css"
             }
           }
         ],
@@ -34,7 +34,7 @@
             "line": 3,
             "column": 10
           },
-          "filename": "messed-up.css"
+          "source": "messed-up.css"
         }
       },
       {
@@ -56,7 +56,7 @@
                 "line": 5,
                 "column": 16
               },
-              "filename": "messed-up.css"
+              "source": "messed-up.css"
             }
           },
           {
@@ -72,7 +72,7 @@
                 "line": 5,
                 "column": 24
               },
-              "filename": "messed-up.css"
+              "source": "messed-up.css"
             }
           }
         ],
@@ -85,7 +85,7 @@
             "line": 5,
             "column": 25
           },
-          "filename": "messed-up.css"
+          "source": "messed-up.css"
         }
       },
       {
@@ -107,7 +107,7 @@
                 "line": 11,
                 "column": 6
               },
-              "filename": "messed-up.css"
+              "source": "messed-up.css"
             }
           },
           {
@@ -123,7 +123,7 @@
                 "line": 15,
                 "column": 6
               },
-              "filename": "messed-up.css"
+              "source": "messed-up.css"
             }
           }
         ],
@@ -136,7 +136,7 @@
             "line": 15,
             "column": 7
           },
-          "filename": "messed-up.css"
+          "source": "messed-up.css"
         }
       }
     ]

--- a/test/cases/namespace.json
+++ b/test/cases/namespace.json
@@ -14,7 +14,7 @@
             "line": 1,
             "column": 43
           },
-          "filename": "namespace.css"
+          "source": "namespace.css"
         }
       },
       {
@@ -29,7 +29,7 @@
             "line": 2,
             "column": 45
           },
-          "filename": "namespace.css"
+          "source": "namespace.css"
         }
       }
     ]

--- a/test/cases/no-semi.json
+++ b/test/cases/no-semi.json
@@ -21,7 +21,7 @@
                 "line": 3,
                 "column": 13
               },
-              "filename": "no-semi.css"
+              "source": "no-semi.css"
             }
           },
           {
@@ -37,7 +37,7 @@
                 "line": 5,
                 "column": 1
               },
-              "filename": "no-semi.css"
+              "source": "no-semi.css"
             }
           }
         ],
@@ -50,7 +50,7 @@
             "line": 5,
             "column": 2
           },
-          "filename": "no-semi.css"
+          "source": "no-semi.css"
         }
       }
     ]

--- a/test/cases/paged-media.json
+++ b/test/cases/paged-media.json
@@ -14,7 +14,7 @@
             "line": 1,
             "column": 16
           },
-          "filename": "paged-media.css"
+          "source": "paged-media.css"
         }
       },
       {
@@ -36,7 +36,7 @@
                 "line": 3,
                 "column": 19
               },
-              "filename": "paged-media.css"
+              "source": "paged-media.css"
             }
           },
           {
@@ -52,7 +52,7 @@
                 "line": 4,
                 "column": 15
               },
-              "filename": "paged-media.css"
+              "source": "paged-media.css"
             }
           }
         ],
@@ -65,7 +65,7 @@
             "line": 5,
             "column": 2
           },
-          "filename": "paged-media.css"
+          "source": "paged-media.css"
         }
       },
       {
@@ -85,7 +85,7 @@
                 "line": 8,
                 "column": 18
               },
-              "filename": "paged-media.css"
+              "source": "paged-media.css"
             }
           }
         ],
@@ -98,7 +98,7 @@
             "line": 9,
             "column": 2
           },
-          "filename": "paged-media.css"
+          "source": "paged-media.css"
         }
       }
     ]

--- a/test/cases/props.json
+++ b/test/cases/props.json
@@ -21,7 +21,7 @@
                 "line": 3,
                 "column": 13
               },
-              "filename": "props.css"
+              "source": "props.css"
             }
           },
           {
@@ -37,7 +37,7 @@
                 "line": 4,
                 "column": 32
               },
-              "filename": "props.css"
+              "source": "props.css"
             }
           },
           {
@@ -53,7 +53,7 @@
                 "line": 5,
                 "column": 19
               },
-              "filename": "props.css"
+              "source": "props.css"
             }
           }
         ],
@@ -66,7 +66,7 @@
             "line": 6,
             "column": 2
           },
-          "filename": "props.css"
+          "source": "props.css"
         }
       }
     ]

--- a/test/cases/quoted.json
+++ b/test/cases/quoted.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 55
               },
-              "filename": "quoted.css"
+              "source": "quoted.css"
             }
           }
         ],
@@ -34,7 +34,7 @@
             "line": 3,
             "column": 2
           },
-          "filename": "quoted.css"
+          "source": "quoted.css"
         }
       }
     ]

--- a/test/cases/rule.json
+++ b/test/cases/rule.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 13
               },
-              "filename": "rule.css"
+              "source": "rule.css"
             }
           }
         ],
@@ -34,7 +34,7 @@
             "line": 3,
             "column": 2
           },
-          "filename": "rule.css"
+          "source": "rule.css"
         }
       }
     ]

--- a/test/cases/rules.json
+++ b/test/cases/rules.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 15
               },
-              "filename": "rules.css"
+              "source": "rules.css"
             }
           }
         ],
@@ -34,7 +34,7 @@
             "line": 3,
             "column": 2
           },
-          "filename": "rules.css"
+          "source": "rules.css"
         }
       },
       {
@@ -56,7 +56,7 @@
                 "line": 5,
                 "column": 15
               },
-              "filename": "rules.css"
+              "source": "rules.css"
             }
           }
         ],
@@ -69,7 +69,7 @@
             "line": 6,
             "column": 2
           },
-          "filename": "rules.css"
+          "source": "rules.css"
         }
       }
     ]

--- a/test/cases/supports.json
+++ b/test/cases/supports.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 19
               },
-              "filename": "supports.css"
+              "source": "supports.css"
             }
           },
           {
@@ -39,7 +39,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "filename": "supports.css"
+                  "source": "supports.css"
                 }
               },
               {
@@ -55,7 +55,7 @@
                     "line": 5,
                     "column": 17
                   },
-                  "filename": "supports.css"
+                  "source": "supports.css"
                 }
               },
               {
@@ -71,7 +71,7 @@
                     "line": 6,
                     "column": 18
                   },
-                  "filename": "supports.css"
+                  "source": "supports.css"
                 }
               }
             ],
@@ -84,7 +84,7 @@
                 "line": 7,
                 "column": 4
               },
-              "filename": "supports.css"
+              "source": "supports.css"
             }
           }
         ],
@@ -97,7 +97,7 @@
             "line": 8,
             "column": 2
           },
-          "filename": "supports.css"
+          "source": "supports.css"
         }
       }
     ]

--- a/test/cases/wtf.json
+++ b/test/cases/wtf.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 22
               },
-              "filename": "wtf.css"
+              "source": "wtf.css"
             }
           },
           {
@@ -37,7 +37,7 @@
                 "line": 3,
                 "column": 22
               },
-              "filename": "wtf.css"
+              "source": "wtf.css"
             }
           },
           {
@@ -53,7 +53,7 @@
                 "line": 4,
                 "column": 16
               },
-              "filename": "wtf.css"
+              "source": "wtf.css"
             }
           }
         ],
@@ -66,7 +66,7 @@
             "line": 5,
             "column": 2
           },
-          "filename": "wtf.css"
+          "source": "wtf.css"
         }
       }
     ]

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -26,14 +26,13 @@ describe('parse(str)', function(){
   it('should save the filename and source', function(){
     var css = 'booty {\n  size: large;\n}\n';
     var ast = parse(css, {
-      filename: 'booty.css'
+      source: 'booty.css'
     });
 
     var position = ast.stylesheet.rules[0].position
     position.start.should.be.ok;
     position.end.should.be.ok;
-    position.filename.should.equal('booty.css');
-    position.source.should.equal(css);
+    position.source.should.equal('booty.css');
   });
 
   it('should throw when a selector is missing', function(){

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -17,7 +17,7 @@ describe('parse(str)', function(){
     it('should parse ' + file, function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
       var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
-      var ret = parse(css, { filename: file + '.css' });
+      var ret = parse(css, { source: file + '.css' });
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);
     })

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -33,6 +33,7 @@ describe('parse(str)', function(){
     position.start.should.be.ok;
     position.end.should.be.ok;
     position.source.should.equal('booty.css');
+    position.content.should.equal(css);
   });
 
   it('should throw when a selector is missing', function(){


### PR DESCRIPTION
(In reference to the changes mentioned in reworkcss/rework#144)

This reverts 190ba98 and removes some of the references to `filename` that were also added.
