### PR TITLE
Add support for @font-face, which should not be considered a selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ module.exports = function(css, options){
   function selector() {
     var m = match(/^([^{]+)/);
     if (!m) return;
-    /* @fix Remove all comments from selectors 
+    /* @fix Remove all comments from selectors
      * http://ostermiller.org/findcomment.html */
     return trim(m[0]).replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '').split(/\s*,\s*/);
   }
@@ -431,6 +431,33 @@ module.exports = function(css, options){
   }
 
   /**
+   * Parse font-face.
+   */
+
+  function atfontface() {
+    var pos = position();
+    var m = match(/^@font-face */);
+    if (!m) return;
+
+    if (!open()) return error("@font-face missing '{'");
+    var decls = comments();
+
+    // declarations
+    var decl;
+    while (decl = declaration()) {
+      decls.push(decl);
+      decls = decls.concat(comments());
+    }
+
+    if (!close()) return error("@font-face missing '}'");
+
+    return pos({
+      type: 'font-face',
+      declarations: decls
+    });
+  }
+
+  /**
    * Parse import
    */
 
@@ -480,7 +507,8 @@ module.exports = function(css, options){
       || atnamespace()
       || atdocument()
       || atpage()
-      || athost();
+      || athost()
+      || atfontface();
   }
 
   /**

--- a/test/cases/font-face.css
+++ b/test/cases/font-face.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: "Bitstream Vera Serif Bold";
+  src: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");
+}
+
+body {
+  font-family: "Bitstream Vera Serif Bold", serif;
+}

--- a/test/cases/font-face.json
+++ b/test/cases/font-face.json
@@ -1,0 +1,90 @@
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "font-face",
+        "declarations": [
+          {
+            "type": "declaration",
+            "property": "font-family",
+            "value": "\"Bitstream Vera Serif Bold\"",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 43
+              },
+              "source": "font-face.css"
+            }
+          },
+          {
+            "type": "declaration",
+            "property": "src",
+            "value": "url(\"http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf\")",
+            "position": {
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 78
+              },
+              "source": "font-face.css"
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          },
+          "source": "font-face.css"
+        }
+      },
+      {
+        "type": "rule",
+        "selectors": [
+          "body"
+        ],
+        "declarations": [
+          {
+            "type": "declaration",
+            "property": "font-family",
+            "value": "\"Bitstream Vera Serif Bold\", serif",
+            "position": {
+              "start": {
+                "line": 7,
+                "column": 3
+              },
+              "end": {
+                "line": 7,
+                "column": 50
+              },
+              "source": "font-face.css"
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 6,
+            "column": 1
+          },
+          "end": {
+            "line": 8,
+            "column": 2
+          },
+          "source": "font-face.css"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This change parses `@font-face` rules as an at-rule, instead of treating them as a standard rule with `@font-face` being the selector.
