### PR TITLE
Add support for -ms-lang() in selectors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ module.exports = function(css, options){
     if (!m) return;
     /* @fix Remove all comments from selectors
      * http://ostermiller.org/findcomment.html */
-    return trim(m[0]).replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '').split(/\s*,\s*/);
+    return trim(m[0]).replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '').split(/\s*(?![^(]*\)),\s*/);
   }
 
   /**

--- a/test/cases/ms-lang.css
+++ b/test/cases/ms-lang.css
@@ -1,3 +1,3 @@
-foo:-ms-lang( ar, dv, fa, he, ku-Arab, pa-Arab, prs, ps, sd-Arab, syr, ug, ur, qps-plocm) {
+foo:-ms-lang(ar, dv, fa, he, ku-Arab, pa-Arab, prs, ps, sd-Arab, syr, ug, ur, qps-plocm) {
   bar: 'baz';
 }

--- a/test/cases/ms-lang.css
+++ b/test/cases/ms-lang.css
@@ -1,0 +1,3 @@
+foo:-ms-lang( ar, dv, fa, he, ku-Arab, pa-Arab, prs, ps, sd-Arab, syr, ug, ur, qps-plocm) {
+  bar: 'baz';
+}

--- a/test/cases/ms-lang.json
+++ b/test/cases/ms-lang.json
@@ -21,7 +21,7 @@
                 "line": 2,
                 "column": 13
               },
-              "source": "rule.css"
+              "source": "ms-lang.css"
             }
           }
         ],
@@ -34,7 +34,7 @@
             "line": 3,
             "column": 2
           },
-          "source": "rule.css"
+          "source": "ms-lang.css"
         }
       }
     ]

--- a/test/cases/ms-lang.json
+++ b/test/cases/ms-lang.json
@@ -1,0 +1,42 @@
+{
+  "type": "stylesheet",
+  "stylesheet": {
+    "rules": [
+      {
+        "type": "rule",
+        "selectors": [
+          "foo:-ms-lang(ar, dv, fa, he, ku-Arab, pa-Arab, prs, ps, sd-Arab, syr, ug, ur, qps-plocm)"
+        ],
+        "declarations": [
+          {
+            "type": "declaration",
+            "property": "bar",
+            "value": "'baz'",
+            "position": {
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              },
+              "source": "rule.css"
+            }
+          }
+        ],
+        "position": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          },
+          "source": "rule.css"
+        }
+      }
+    ]
+  }
+}

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -18,6 +18,7 @@ describe('parse(str)', function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
       var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
       var ret = parse(css, { source: file + '.css' });
+      // Normalize line endings from input file
       json = JSON.parse(json);
       json = JSON.stringify(json, null, 2);
       ret = JSON.stringify(ret, null, 2);

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -18,6 +18,8 @@ describe('parse(str)', function(){
       var css = read(path.join('test', 'cases', file + '.css'), 'utf8');
       var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
       var ret = parse(css, { source: file + '.css' });
+      json = JSON.parse(json);
+      json = JSON.stringify(ret, null, 2);
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);
     })

--- a/test/css-parse.js
+++ b/test/css-parse.js
@@ -19,7 +19,7 @@ describe('parse(str)', function(){
       var json = read(path.join('test', 'cases', file + '.json'), 'utf8');
       var ret = parse(css, { source: file + '.css' });
       json = JSON.parse(json);
-      json = JSON.stringify(ret, null, 2);
+      json = JSON.stringify(json, null, 2);
       ret = JSON.stringify(ret, null, 2);
       ret.should.equal(json);
     })


### PR DESCRIPTION
This change modifies the regex used to split selectors, such that commas between ()s are ignored. 
