### PR TITLE
Updated to CSS 3.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
-    "css": "^2.0.0"
-  },
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "license": "MIT",
   "repository": {
@@ -19,5 +16,8 @@
     "css",
     "parser",
     "stylesheet"
-  ]
+  ],
+  "dependencies": {
+    "css": "^3.0.0"
+  }
 }


### PR DESCRIPTION
Avoids using deprecated package `urix@0.1.0`